### PR TITLE
out_s3: mitigate SEGV/heap corruption

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -92,6 +92,7 @@ static void s3_chunk_retry_exhausted_cleanup(struct flb_s3 *ctx,
                                              struct s3_file *chunk_file);
 static int s3_get_retry_exhausted_action(const char *value);
 static void s3_upload_queue(struct flb_config *config, void *out_context);
+static void cb_s3_upload_queue(struct flb_config *config, void *out_context);
 static void s3_upload_queue_retry_cancel(struct flb_s3 *ctx);
 static void s3_upload_queue_release(struct flb_s3 *ctx);
 static int enqueue_oldest_timed_out_chunk(struct flb_s3 *ctx, time_t now,
@@ -951,6 +952,8 @@ static int cb_s3_init(struct flb_output_instance *ins,
                 return -1;
             }
             if (enable_parquet_format(ctx) == -1) {
+                s3_context_destroy(ctx);
+                flb_output_set_context(ins, NULL);
                 return -1;
             }
         }
@@ -962,6 +965,8 @@ static int cb_s3_init(struct flb_output_instance *ins,
                 return -1;
             }
             if (enable_arrow_format(ctx) == -1) {
+                s3_context_destroy(ctx);
+                flb_output_set_context(ins, NULL);
                 return -1;
             }
         }
@@ -1429,10 +1434,9 @@ skip_size_validation:
     }
 
     /*
-     * S3 must ALWAYS use sync mode
-     * In the timer thread we do a mk_list_foreach_safe on the queue of uplaods and chunks
-     * Iterating over those lists is not concurrent safe. If a flush call ran at the same time
-     * And deleted an item from the list, this could cause a crash/corruption.
+     * Log uploads must use synchronous I/O: flush and timer callbacks hold
+     * files_mutex until all borrowed chunk and upload references are released.
+     * Yielding while holding it could deadlock another callback on this worker.
      */
     flb_stream_disable_async_mode(&ctx->s3_client->upstream->base);
 
@@ -1539,6 +1543,11 @@ static int cb_s3_worker_exit(void *data, struct flb_config *config)
     }
 
     flb_plg_info(ctx->ins, "terminating worker");
+
+    /* Do not leave a shared pointer into this worker's retiring scheduler. */
+    pthread_mutex_lock(&ctx->files_mutex);
+    s3_upload_queue_retry_cancel(ctx);
+    pthread_mutex_unlock(&ctx->files_mutex);
 
     info = FLB_TLS_GET(s3_worker_info);
     if (info != NULL) {
@@ -2417,6 +2426,11 @@ static void s3_upload_queue_retry_cancel(struct flb_s3 *ctx)
         return;
     }
 
+    /* Scheduler lists belong to their worker. Let a foreign timer fire. */
+    if (ctx->upload_queue_retry_timer->sched != flb_sched_ctx_get()) {
+        return;
+    }
+
     flb_sched_timer_invalidate(ctx->upload_queue_retry_timer);
     ctx->upload_queue_retry_timer = NULL;
 }
@@ -2445,8 +2459,19 @@ static void s3_upload_queue_retry(struct flb_config *config, void *out_context)
 {
     struct flb_s3 *ctx = out_context;
 
+    pthread_mutex_lock(&ctx->files_mutex);
     ctx->upload_queue_retry_timer = NULL;
     s3_upload_queue(config, out_context);
+    pthread_mutex_unlock(&ctx->files_mutex);
+}
+
+static void cb_s3_upload_queue(struct flb_config *config, void *out_context)
+{
+    struct flb_s3 *ctx = out_context;
+
+    pthread_mutex_lock(&ctx->files_mutex);
+    s3_upload_queue(config, out_context);
+    pthread_mutex_unlock(&ctx->files_mutex);
 }
 
 static int s3_upload_queue_retry_schedule(struct flb_s3 *ctx, time_t retry_time)
@@ -4141,7 +4166,7 @@ static void complete_pending_uploads_once(struct flb_s3 *ctx, int *checked)
     *checked = FLB_TRUE;
 }
 
-static void cb_s3_upload(struct flb_config *config, void *data)
+static void s3_upload(struct flb_config *config, void *data)
 {
     struct flb_s3 *ctx = data;
     struct s3_file *chunk = NULL;
@@ -4215,6 +4240,15 @@ static void cb_s3_upload(struct flb_config *config, void *data)
 
     complete_pending_uploads(ctx);
 
+}
+
+static void cb_s3_upload(struct flb_config *config, void *data)
+{
+    struct flb_s3 *ctx = data;
+
+    pthread_mutex_lock(&ctx->files_mutex);
+    s3_upload(config, data);
+    pthread_mutex_unlock(&ctx->files_mutex);
 }
 
 static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, const char *data,
@@ -4373,7 +4407,7 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, const char 
     return out_buf;
 }
 
-static void flush_init(void *out_context)
+static int flush_init(void *out_context)
 {
     int ret;
     struct flb_s3 *ctx = out_context;
@@ -4393,7 +4427,7 @@ static void flush_init(void *out_context)
                           "Failed to send locally buffered data left over "
                           "from previous executions; will retry. Buffer=%s",
                           ctx->fs->root_path);
-            FLB_OUTPUT_RETURN(FLB_RETRY);
+            return -1;
         }
     }
 
@@ -4411,7 +4445,7 @@ static void flush_init(void *out_context)
 
         if (ctx->preserve_data_ordering) {
             ret = flb_sched_timer_cb_create(sched, FLB_SCHED_TIMER_CB_PERM,
-                                            ctx->timer_ms, s3_upload_queue, ctx, NULL);
+                                            ctx->timer_ms, cb_s3_upload_queue, ctx, NULL);
         }
         else {
             ret = flb_sched_timer_cb_create(sched, FLB_SCHED_TIMER_CB_PERM,
@@ -4419,10 +4453,12 @@ static void flush_init(void *out_context)
         }
         if (ret == -1) {
             flb_plg_error(ctx->ins, "Failed to create upload timer");
-            FLB_OUTPUT_RETURN(FLB_RETRY);
+            return -1;
         }
         ctx->timer_created = FLB_TRUE;
     }
+
+    return 0;
 }
 
 static int blob_chunk_register_parts(struct flb_s3 *ctx, uint64_t file_id, size_t total_size)
@@ -4615,11 +4651,8 @@ static flb_sds_t s3_format_event_chunk(struct flb_s3 *ctx,
                                            config->json_escape_unicode);
 }
 
-static void cb_s3_flush(struct flb_event_chunk *event_chunk,
-                        struct flb_output_flush *out_flush,
-                        struct flb_input_instance *i_ins,
-                        void *out_context,
-                        struct flb_config *config)
+static int s3_flush_logs(struct flb_event_chunk *event_chunk,
+                         struct flb_s3 *ctx, struct flb_config *config)
 {
     int ret;
     int chunk_size;
@@ -4627,33 +4660,22 @@ static void cb_s3_flush(struct flb_event_chunk *event_chunk,
     int total_file_size_check = FLB_FALSE;
     flb_sds_t chunk = NULL;
     struct s3_file *upload_file = NULL;
-    struct flb_s3 *ctx = out_context;
     struct multipart_upload *m_upload_file = NULL;
     time_t file_first_log_time = 0;
     struct flb_log_event_decoder log_decoder;
     struct flb_log_event log_event;
 
-    if (event_chunk->type == FLB_EVENT_TYPE_BLOBS) {
-        /*
-         * For Blob types, we use the flush callback to enqueue the file, then cb_azb_blob_file_upload()
-         * takes care of the rest like reading the file and uploading it to S3.
-         */
-        ret = process_blob_chunk(ctx, event_chunk);
-        if (ret == -1) {
-            FLB_OUTPUT_RETURN(FLB_RETRY);
-        }
-
-        FLB_OUTPUT_RETURN(FLB_OK);
+    /* Cleanup old buffers and initialize upload timer. */
+    ret = flush_init(ctx);
+    if (ret < 0) {
+        return FLB_RETRY;
     }
-
-    /* Cleanup old buffers and initialize upload timer */
-    flush_init(ctx);
 
     /* Process chunk */
     chunk = s3_format_event_chunk(ctx, event_chunk, config);
     if (chunk == NULL) {
         flb_plg_error(ctx->ins, "Could not marshal msgpack to output string");
-        FLB_OUTPUT_RETURN(FLB_ERROR);
+        return FLB_ERROR;
     }
     chunk_size = flb_sds_len(chunk);
 
@@ -4673,7 +4695,7 @@ static void cb_s3_flush(struct flb_event_chunk *event_chunk,
 
             flb_sds_destroy(chunk);
 
-            FLB_OUTPUT_RETURN(FLB_ERROR);
+            return FLB_ERROR;
         }
 
         while ((ret = flb_log_event_decoder_next(
@@ -4737,7 +4759,7 @@ static void cb_s3_flush(struct flb_event_chunk *event_chunk,
                                file_first_log_time);
 
             if (ret < 0) {
-                FLB_OUTPUT_RETURN(FLB_RETRY);
+                return FLB_RETRY;
             }
             s3_store_file_lock(upload_file);
 
@@ -4745,16 +4767,16 @@ static void cb_s3_flush(struct flb_event_chunk *event_chunk,
             ret = add_to_queue(ctx, upload_file, m_upload_file,
                                event_chunk->tag, flb_sds_len(event_chunk->tag));
             if (ret < 0) {
-                FLB_OUTPUT_RETURN(FLB_ERROR);
+                return FLB_ERROR;
             }
 
             /* Go through upload queue and return error if something went wrong */
             s3_upload_queue(config, ctx);
             if (ctx->upload_queue_success == FLB_FALSE) {
                 ctx->upload_queue_success = FLB_TRUE;
-                FLB_OUTPUT_RETURN(FLB_ERROR);
+                return FLB_ERROR;
             }
-            FLB_OUTPUT_RETURN(FLB_OK);
+            return FLB_OK;
         }
         else {
             /* Send upload directly without upload queue */
@@ -4762,9 +4784,9 @@ static void cb_s3_flush(struct flb_event_chunk *event_chunk,
                                       event_chunk->tag,
                                       flb_sds_len(event_chunk->tag));
             if (ret < 0) {
-                FLB_OUTPUT_RETURN(FLB_ERROR);
+                return FLB_ERROR;
             }
-            FLB_OUTPUT_RETURN(ret);
+            return ret;
         }
     }
 
@@ -4774,9 +4796,38 @@ static void cb_s3_flush(struct flb_event_chunk *event_chunk,
                        file_first_log_time);
 
     if (ret < 0) {
-        FLB_OUTPUT_RETURN(FLB_RETRY);
+        return FLB_RETRY;
     }
-    FLB_OUTPUT_RETURN(FLB_OK);
+    return FLB_OK;
+}
+
+static void cb_s3_flush(struct flb_event_chunk *event_chunk,
+                        struct flb_output_flush *out_flush,
+                        struct flb_input_instance *i_ins,
+                        void *out_context,
+                        struct flb_config *config)
+{
+    int ret;
+    struct flb_s3 *ctx = out_context;
+
+    if (event_chunk->type == FLB_EVENT_TYPE_BLOBS) {
+        ret = process_blob_chunk(ctx, event_chunk);
+        if (ret == -1) {
+            FLB_OUTPUT_RETURN(FLB_RETRY);
+        }
+        FLB_OUTPUT_RETURN(FLB_OK);
+    }
+
+    /*
+     * Keep the store, upload queue and multipart state owned by one callback
+     * until synchronous I/O and cleanup finish. Locking only the lookup or
+     * append leaves returned pointers exposed to another worker's deletion.
+     */
+    pthread_mutex_lock(&ctx->files_mutex);
+    ret = s3_flush_logs(event_chunk, ctx, config);
+    pthread_mutex_unlock(&ctx->files_mutex);
+
+    FLB_OUTPUT_RETURN(ret);
 }
 
 static int cb_s3_exit(void *data, struct flb_config *config)

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -18,6 +18,7 @@
  */
 
 #include <fluent-bit/flb_output_plugin.h>
+#include <fluent-bit/flb_env.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_slist.h>
 #include <fluent-bit/flb_time.h>
@@ -99,6 +100,79 @@ static int enqueue_oldest_timed_out_chunk(struct flb_s3 *ctx, time_t now,
                                           int skip_held_tags);
 static void complete_pending_uploads(struct flb_s3 *ctx);
 static void complete_pending_uploads_once(struct flb_s3 *ctx, int *checked);
+
+/* Claims keep a tag's chunks and multipart state owned across unlocked I/O. */
+struct s3_upload_claim {
+    const char *tag;
+    int tag_len;
+    struct mk_list _head;
+};
+
+static int s3_tag_busy(struct flb_s3 *ctx, const char *tag, int tag_len)
+{
+    struct mk_list *head;
+    struct s3_upload_claim *claim;
+
+    mk_list_foreach(head, &ctx->upload_claims) {
+        claim = mk_list_entry(head, struct s3_upload_claim, _head);
+        if (ctx->key_fmt_has_seq_index ||
+            (claim->tag_len == tag_len && memcmp(claim->tag, tag, tag_len) == 0)) {
+            return FLB_TRUE;
+        }
+    }
+    return FLB_FALSE;
+}
+
+static void s3_claim_start(struct flb_s3 *ctx, struct s3_upload_claim *claim,
+                           const char *tag, int tag_len)
+{
+    claim->tag = tag;
+    claim->tag_len = tag_len;
+    mk_list_add(&claim->_head, &ctx->upload_claims);
+}
+
+static void s3_claim_end(struct s3_upload_claim *claim)
+{
+    mk_list_del(&claim->_head);
+}
+
+/* Snapshot mutable client state while allowing independent network requests. */
+struct flb_http_client *s3_request(struct flb_s3 *ctx,
+                                  int method, const char *uri,
+                                  const char *body, size_t body_size,
+                                  struct flb_aws_header *headers, size_t headers_count)
+{
+    struct flb_aws_client client;
+    struct flb_http_client *response;
+
+    client = *ctx->s3_client;
+    pthread_mutex_unlock(&ctx->files_mutex);
+    response = client.client_vtable->request(&client, method, uri, body, body_size,
+                                             headers, headers_count);
+    pthread_mutex_lock(&ctx->files_mutex);
+    if (ctx->s3_client->extra_user_agent == NULL) {
+        ctx->s3_client->extra_user_agent = client.extra_user_agent;
+    }
+    else if (client.extra_user_agent != ctx->s3_client->extra_user_agent) {
+        flb_sds_destroy(client.extra_user_agent);
+    }
+    if (client.refresh_limit > ctx->s3_client->refresh_limit) {
+        ctx->s3_client->refresh_limit = client.refresh_limit;
+    }
+    return response;
+}
+
+static struct flb_http_client *s3_blob_request(struct flb_s3 *ctx, int method,
+                                              const char *uri, const char *body, size_t body_size,
+                                              struct flb_aws_header *headers, size_t headers_count)
+{
+    struct flb_http_client *response;
+
+    pthread_mutex_lock(&ctx->files_mutex);
+    response = s3_request(ctx, method, uri, body, body_size, headers, headers_count);
+    pthread_mutex_unlock(&ctx->files_mutex);
+    return response;
+}
 
 static int blob_initialize_authorization_endpoint_upstream(struct flb_s3 *context);
 
@@ -842,6 +916,26 @@ static void s3_context_destroy(struct flb_s3 *ctx)
     flb_free(ctx);
 }
 
+static int s3_init_user_agent(struct flb_config *config)
+{
+    const char *value;
+
+    if (flb_env_get(config->env, "FLB_AWS_USER_AGENT") != NULL) {
+        return 0;
+    }
+    value = flb_env_get(config->env, "k8s");
+    if (getenv("ECS_CONTAINER_METADATA_URI_V4") != NULL) {
+        value = "ecs";
+    }
+    else if (value != NULL && strcasecmp(value, "enabled") == 0) {
+        value = "k8s";
+    }
+    else {
+        value = "none";
+    }
+    return flb_env_set(config->env, "FLB_AWS_USER_AGENT", value);
+}
+
 static int cb_s3_init(struct flb_output_instance *ins,
                       struct flb_config *config, void *data)
 {
@@ -858,6 +952,10 @@ static int cb_s3_init(struct flb_output_instance *ins,
     struct flb_split_entry *tok;
     struct mk_list *split;
     int list_size;
+
+    if (s3_init_user_agent(config) < 0) {
+        return -1;
+    }
 
     FLB_TLS_INIT(s3_worker_info);
 
@@ -877,6 +975,7 @@ static int cb_s3_init(struct flb_output_instance *ins,
 
     mk_list_init(&ctx->uploads);
     mk_list_init(&ctx->upload_queue);
+    mk_list_init(&ctx->upload_claims);
 
     ctx->retry_time = 0;
     ctx->upload_queue_success = FLB_FALSE;
@@ -1434,9 +1533,8 @@ skip_size_validation:
     }
 
     /*
-     * Log uploads must use synchronous I/O: flush and timer callbacks hold
-     * files_mutex until all borrowed chunk and upload references are released.
-     * Yielding while holding it could deadlock another callback on this worker.
+     * Log uploads use synchronous I/O. Upload claims protect borrowed objects
+     * while the store mutex is released for compression and network requests.
      */
     flb_stream_disable_async_mode(&ctx->s3_client->upstream->base);
 
@@ -1460,7 +1558,9 @@ skip_size_validation:
                      "executions to S3; buffer=%s",
                      ctx->fs->root_path);
         ctx->has_old_buffers = FLB_FALSE;
+        pthread_mutex_lock(&ctx->files_mutex);
         ret = put_all_chunks(ctx, FLB_TRUE);
+        pthread_mutex_unlock(&ctx->files_mutex);
         if (ret < 0) {
             ctx->has_old_buffers = FLB_TRUE;
             flb_plg_error(ctx->ins,
@@ -1563,7 +1663,7 @@ static int cb_s3_worker_exit(void *data, struct flb_config *config)
  *
  * Chunk is allowed to be NULL
  */
-static int upload_data(struct flb_s3 *ctx, struct s3_file *chunk,
+static int upload_data_owned(struct flb_s3 *ctx, struct s3_file *chunk,
                        struct multipart_upload *m_upload,
                        char *body, size_t body_size,
                        const char *tag, int tag_len)
@@ -1592,10 +1692,12 @@ static int upload_data(struct flb_s3 *ctx, struct s3_file *chunk,
 
 #ifdef FLB_HAVE_ARROW
     if (s3_format_is_columnar(ctx->s3_format)) {
+        pthread_mutex_unlock(&ctx->files_mutex);
         ret = flb_aws_compression_compress_columnar(
                     s3_format_to_aws_compress_format(ctx->s3_format),
                     body, body_size, &payload_buf,
                     &payload_size, ctx->compression);
+        pthread_mutex_lock(&ctx->files_mutex);
         if (ret == -1) {
             flb_plg_error(ctx->ins, "Failed to convert data to columnar "
                           "format");
@@ -1613,8 +1715,10 @@ static int upload_data(struct flb_s3 *ctx, struct s3_file *chunk,
     else
 #endif
     if (ctx->compression != FLB_AWS_COMPRESS_NONE) {
+        pthread_mutex_unlock(&ctx->files_mutex);
         ret = flb_aws_compression_compress(ctx->compression, body, body_size,
                                            &payload_buf, &payload_size);
+        pthread_mutex_lock(&ctx->files_mutex);
         if (ret == -1) {
             flb_plg_error(ctx->ins, "Failed to compress data");
             if (chunk != NULL) {
@@ -1784,6 +1888,19 @@ multipart:
     return FLB_OK;
 }
 
+static int upload_data(struct flb_s3 *ctx, struct s3_file *chunk,
+                       struct multipart_upload *m_upload,
+                       char *body, size_t body_size, const char *tag, int tag_len)
+{
+    int ret;
+    struct s3_upload_claim claim;
+
+    s3_claim_start(ctx, &claim, tag, tag_len);
+    ret = upload_data_owned(ctx, chunk, m_upload, body, body_size, tag, tag_len);
+    s3_claim_end(&claim);
+    return ret;
+}
+
 /*
  * Attempts to send all chunks to S3 using PutObject
  * Used on shut down to try to send all buffered data
@@ -1804,7 +1921,12 @@ static int put_all_chunks(struct flb_s3 *ctx, int cleanup_empty_streams)
     char *buffer = NULL;
     size_t buffer_size;
     int ret;
+    uint64_t scan_id;
+    struct s3_upload_claim claim;
 
+    scan_id = ++ctx->upload_scan_id;
+
+restart:
     mk_list_foreach_safe(head, stream_tmp, &ctx->fs->streams) {
         /* skip multi upload stream */
         fs_stream = mk_list_entry(head, struct flb_fstore_stream, _head);
@@ -1824,7 +1946,8 @@ static int put_all_chunks(struct flb_s3 *ctx, int cleanup_empty_streams)
             chunk = fsf->data;
 
             /* Locked chunks are being processed, skip */
-            if (chunk->locked == FLB_TRUE) {
+            if (chunk->locked == FLB_TRUE || chunk->upload_scan_id >= scan_id ||
+                s3_tag_busy(ctx, (const char *) fsf->meta_buf, fsf->meta_size)) {
                 continue;
             }
 
@@ -1836,6 +1959,7 @@ static int put_all_chunks(struct flb_s3 *ctx, int cleanup_empty_streams)
                 continue;
             }
 
+            chunk->upload_scan_id = scan_id;
             ret = construct_request_buffer(ctx, NULL, chunk,
                                            &buffer, &buffer_size);
             if (ret < 0) {
@@ -1850,6 +1974,8 @@ static int put_all_chunks(struct flb_s3 *ctx, int cleanup_empty_streams)
                 continue;
             }
 
+            s3_claim_start(ctx, &claim, (const char *) fsf->meta_buf, fsf->meta_size);
+            pthread_mutex_unlock(&ctx->files_mutex);
 #ifdef FLB_HAVE_ARROW
             if (s3_format_is_columnar(ctx->s3_format)) {
                 ret = flb_aws_compression_compress_columnar(
@@ -1891,10 +2017,12 @@ static int put_all_chunks(struct flb_s3 *ctx, int cleanup_empty_streams)
                 }
             }
 
+            pthread_mutex_lock(&ctx->files_mutex);
             ret = s3_put_object(ctx, (const char *)
                                 fsf->meta_buf,
                                 chunk->create_time, buffer, buffer_size);
             flb_free(buffer);
+            s3_claim_end(&claim);
             if (ret < 0) {
                 s3_store_file_unlock(chunk);
                 chunk->failures += 1;
@@ -1903,11 +2031,12 @@ static int put_all_chunks(struct flb_s3 *ctx, int cleanup_empty_streams)
                     ctx->key_fmt_has_seq_index == FLB_TRUE) {
                     return result;
                 }
-                continue;
+                goto restart;
             }
 
             /* data was sent successfully- delete the local buffer */
             s3_store_file_delete(ctx, chunk);
+            goto restart;
         }
 
         if (cleanup_empty_streams == FLB_TRUE &&
@@ -1993,7 +2122,6 @@ static int s3_put_object(struct flb_s3 *ctx, const char *tag, time_t file_first_
 {
     flb_sds_t s3_key = NULL;
     struct flb_http_client *c = NULL;
-    struct flb_aws_client *s3_client;
     struct flb_aws_header *headers = NULL;
     char *random_alphanumeric;
     int append_random = FLB_FALSE;
@@ -2072,7 +2200,6 @@ static int s3_put_object(struct flb_s3 *ctx, const char *tag, time_t file_first_
         }
     }
 
-    s3_client = ctx->s3_client;
     if (s3_plugin_under_test() == FLB_TRUE) {
         c = mock_s3_call_for_tag("TEST_PUT_OBJECT_ERROR",
                                  "TEST_PUT_OBJECT_ERROR_TAG",
@@ -2086,9 +2213,8 @@ static int s3_put_object(struct flb_s3 *ctx, const char *tag, time_t file_first_
             flb_sds_destroy(uri);
             goto decrement_index;
         }
-        c = s3_client->client_vtable->request(s3_client, FLB_HTTP_PUT,
-                                              uri, body, body_size,
-                                              headers, num_headers);
+        c = s3_request(ctx, FLB_HTTP_PUT, uri, body, body_size,
+                         headers, num_headers);
         flb_free(headers);
     }
     if (c) {
@@ -2164,6 +2290,9 @@ static struct multipart_upload *get_upload(struct flb_s3 *ctx,
     mk_list_foreach_safe(head, tmp, &ctx->uploads) {
         tmp_upload = mk_list_entry(head, struct multipart_upload, _head);
 
+        if (s3_tag_busy(ctx, tmp_upload->tag, flb_sds_len(tmp_upload->tag))) {
+            continue;
+        }
         if (tmp_upload->upload_state == MULTIPART_UPLOAD_STATE_COMPLETE_IN_PROGRESS) {
             continue;
         }
@@ -2203,6 +2332,7 @@ static struct multipart_upload *create_upload(struct flb_s3 *ctx, const char *ta
         flb_free(m_upload);
         return NULL;
     }
+    m_upload->request = s3_request;
     m_upload->s3_key = s3_key;
     tmp_sds = flb_sds_create_len(tag, tag_len);
     if (!tmp_sds) {
@@ -2551,6 +2681,7 @@ static int upload_queue_tag_is_held(struct flb_s3 *ctx, const char *tag,
 static void s3_upload_queue(struct flb_config *config, void *out_context)
 {
     int ret;
+    uint64_t scan_id;
     int entry_removed;
     int completions_checked;
     time_t now;
@@ -2562,10 +2693,16 @@ static void s3_upload_queue(struct flb_config *config, void *out_context)
     struct mk_list *head;
 
     (void) config;
+    scan_id = ++ctx->upload_scan_id;
     completions_checked = FLB_FALSE;
     earliest_retry_time = 0;
 
     flb_plg_debug(ctx->ins, "Running upload timer callback (upload_queue)..");
+
+    if (ctx->has_old_buffers) {
+        complete_pending_uploads(ctx);
+        return;
+    }
 
 scan:
 
@@ -2584,9 +2721,15 @@ scan:
         }
     }
 
-    /* Iterate through each file in upload queue */
+restart:
+    /* Never retain list iterators across an unlocked upload. */
     mk_list_foreach_safe(head, tmp, &ctx->upload_queue) {
         upload_contents = mk_list_entry(head, struct upload_queue, _head);
+
+        if (upload_contents->in_flight || upload_contents->scan_id >= scan_id ||
+            s3_tag_busy(ctx, upload_contents->tag, upload_contents->tag_len)) {
+            continue;
+        }
 
         if (upload_queue_tag_is_blocked(ctx, upload_contents) == FLB_TRUE) {
             continue;
@@ -2623,9 +2766,12 @@ scan:
                 ctx, upload_contents->tag, upload_contents->tag_len);
 
         /* Try to upload file. Return value can be -1, FLB_OK, FLB_ERROR, FLB_RETRY. */
+        upload_contents->scan_id = scan_id;
+        upload_contents->in_flight = FLB_TRUE;
         ret = send_upload_request(ctx, NULL, upload_contents->upload_file,
                                   upload_contents->m_upload_file,
                                   upload_contents->tag, upload_contents->tag_len);
+        upload_contents->in_flight = FLB_FALSE;
         if (ret == FLB_OK) {
             s3_upload_queue_retry_cancel(ctx);
             remove_from_queue(upload_contents);
@@ -2652,7 +2798,7 @@ scan:
                 s3_upload_queue_retry_cancel(ctx);
                 ctx->retry_time = 0;
                 complete_pending_uploads_once(ctx, &completions_checked);
-                continue;
+                goto restart;
             }
 
             /* Retry in N seconds */
@@ -2676,6 +2822,7 @@ scan:
                           2 * upload_contents->retry_counter);
             complete_pending_uploads_once(ctx, &completions_checked);
         }
+        goto restart;
     }
 
     if (ctx->key_fmt_has_seq_index == FLB_TRUE) {
@@ -3193,6 +3340,7 @@ static struct multipart_upload *create_blob_upload(struct flb_s3 *ctx, const cha
         flb_free(m_upload);
         return NULL;
     }
+    m_upload->request = s3_blob_request;
     m_upload->s3_key = s3_key;
     tmp_sds = flb_sds_create_len(tag, tag_len);
     if (!tmp_sds) {
@@ -4054,7 +4202,8 @@ static int enqueue_oldest_timed_out_chunk(struct flb_s3 *ctx, time_t now,
         fsf = mk_list_entry(head, struct flb_fstore_file, _head);
         chunk = fsf->data;
 
-        if (chunk->locked == FLB_TRUE) {
+        if (chunk->locked == FLB_TRUE ||
+            s3_tag_busy(ctx, (const char *) fsf->meta_buf, fsf->meta_size)) {
             continue;
         }
 
@@ -4109,10 +4258,19 @@ static void complete_pending_uploads(struct flb_s3 *ctx)
     struct mk_list *head;
     int complete;
     int ret;
+    uint64_t scan_id;
+    struct s3_upload_claim claim;
 
+    scan_id = ++ctx->upload_scan_id;
+
+restart:
     /* Check all uploads and see if any need completion */
     mk_list_foreach_safe(head, tmp, &ctx->uploads) {
         m_upload = mk_list_entry(head, struct multipart_upload, _head);
+        if (m_upload->completion_scan_id >= scan_id ||
+            s3_tag_busy(ctx, m_upload->tag, flb_sds_len(m_upload->tag))) {
+            continue;
+        }
         complete = FLB_FALSE;
 
         if (m_upload->complete_errors > ctx->ins->retry_limit) {
@@ -4140,8 +4298,11 @@ static void complete_pending_uploads(struct flb_s3 *ctx)
         }
         if (complete == FLB_TRUE) {
             m_upload->upload_state = MULTIPART_UPLOAD_STATE_COMPLETE_IN_PROGRESS;
+            m_upload->completion_scan_id = scan_id;
+            s3_claim_start(ctx, &claim, m_upload->tag, flb_sds_len(m_upload->tag));
             mk_list_del(&m_upload->_head);
             ret = complete_multipart_upload(ctx, m_upload, NULL);
+            s3_claim_end(&claim);
             if (ret == 0) {
                 multipart_upload_destroy(m_upload);
             }
@@ -4152,6 +4313,7 @@ static void complete_pending_uploads(struct flb_s3 *ctx)
                 flb_plg_error(ctx->ins, "Could not complete upload %s, will retry..",
                               m_upload->s3_key);
             }
+            goto restart;
         }
     }
 }
@@ -4178,12 +4340,19 @@ static void s3_upload(struct flb_config *config, void *data)
     struct mk_list *head;
     int ret;
     time_t now;
+    uint64_t scan_id;
 
     (void) config;
 
     flb_plg_info(ctx->ins, "Running upload timer callback (cb_s3_upload)..");
 
     now = time(NULL);
+    scan_id = ++ctx->upload_scan_id;
+
+    if (ctx->has_old_buffers) {
+        complete_pending_uploads(ctx);
+        return;
+    }
 
     if (ctx->preserve_data_ordering == FLB_TRUE) {
         ret = enqueue_oldest_timed_out_chunk(ctx, now, FLB_FALSE);
@@ -4195,6 +4364,7 @@ static void s3_upload(struct flb_config *config, void *data)
         return;
     }
 
+restart:
     /* Check all chunks and see if any have timed out */
     mk_list_foreach_safe(head, tmp, &ctx->stream_active->files) {
         fsf = mk_list_entry(head, struct flb_fstore_file, _head);
@@ -4205,12 +4375,14 @@ static void s3_upload(struct flb_config *config, void *data)
         }
 
         /* Locked chunks are being processed, skip */
-        if (chunk->locked == FLB_TRUE) {
+        if (chunk->locked == FLB_TRUE || chunk->upload_scan_id >= scan_id ||
+            s3_tag_busy(ctx, (const char *) fsf->meta_buf, fsf->meta_size)) {
             continue;
         }
 
         m_upload = get_upload(ctx, (const char *) fsf->meta_buf, fsf->meta_size);
 
+        chunk->upload_scan_id = scan_id;
         ret = construct_request_buffer(ctx, NULL, chunk, &buffer, &buffer_size);
         if (ret < 0) {
             flb_plg_error(ctx->ins, "Could not construct request buffer for %s",
@@ -4233,9 +4405,10 @@ static void s3_upload(struct flb_config *config, void *data)
                              (char *) fsf->meta_buf, chunk->failures,
                              ctx->ins->retry_limit);
                 s3_chunk_retry_exhausted_cleanup(ctx, chunk);
-                continue;
+                goto restart;
             }
         }
+        goto restart;
     }
 
     complete_pending_uploads(ctx);
@@ -4414,13 +4587,15 @@ static int flush_init(void *out_context)
     struct flb_sched *sched;
 
     /* clean up any old buffers found on startup */
-    if (ctx->has_old_buffers == FLB_TRUE) {
+    if (ctx->has_old_buffers == FLB_TRUE && ctx->draining_backlog == FLB_FALSE) {
         flb_plg_info(ctx->ins,
                      "Sending locally buffered data from previous "
                      "executions to S3; buffer=%s",
                      ctx->fs->root_path);
-        ctx->has_old_buffers = FLB_FALSE;
+        ctx->draining_backlog = FLB_TRUE;
         ret = put_all_chunks(ctx, FLB_TRUE);
+        ctx->draining_backlog = FLB_FALSE;
+        ctx->has_old_buffers = ret < 0;
         if (ret < 0) {
             ctx->has_old_buffers = FLB_TRUE;
             flb_plg_error(ctx->ins,
@@ -4652,13 +4827,12 @@ static flb_sds_t s3_format_event_chunk(struct flb_s3 *ctx,
 }
 
 static int s3_flush_logs(struct flb_event_chunk *event_chunk,
-                         struct flb_s3 *ctx, struct flb_config *config)
+                         struct flb_s3 *ctx, flb_sds_t chunk)
 {
     int ret;
     int chunk_size;
     int upload_timeout_check = FLB_FALSE;
     int total_file_size_check = FLB_FALSE;
-    flb_sds_t chunk = NULL;
     struct s3_file *upload_file = NULL;
     struct multipart_upload *m_upload_file = NULL;
     time_t file_first_log_time = 0;
@@ -4668,15 +4842,10 @@ static int s3_flush_logs(struct flb_event_chunk *event_chunk,
     /* Cleanup old buffers and initialize upload timer. */
     ret = flush_init(ctx);
     if (ret < 0) {
+        flb_sds_destroy(chunk);
         return FLB_RETRY;
     }
 
-    /* Process chunk */
-    chunk = s3_format_event_chunk(ctx, event_chunk, config);
-    if (chunk == NULL) {
-        flb_plg_error(ctx->ins, "Could not marshal msgpack to output string");
-        return FLB_ERROR;
-    }
     chunk_size = flb_sds_len(chunk);
 
     /* Get a file candidate matching the given 'tag' */
@@ -4716,6 +4885,13 @@ static int s3_flush_logs(struct flb_event_chunk *event_chunk,
 
     if (file_first_log_time == 0) {
         file_first_log_time = time(NULL);
+    }
+
+    if (ctx->has_old_buffers ||
+        s3_tag_busy(ctx, event_chunk->tag, flb_sds_len(event_chunk->tag))) {
+        ret = buffer_chunk(ctx, upload_file, chunk, chunk_size,
+                           event_chunk->tag, flb_sds_len(event_chunk->tag), file_first_log_time);
+        return ret < 0 ? FLB_RETRY : FLB_OK;
     }
 
     /* Discard upload_file if it has failed to upload retry_limit times */
@@ -4771,7 +4947,7 @@ static int s3_flush_logs(struct flb_event_chunk *event_chunk,
             }
 
             /* Go through upload queue and return error if something went wrong */
-            s3_upload_queue(config, ctx);
+            s3_upload_queue(ctx->ins->config, ctx);
             if (ctx->upload_queue_success == FLB_FALSE) {
                 ctx->upload_queue_success = FLB_TRUE;
                 return FLB_ERROR;
@@ -4808,6 +4984,7 @@ static void cb_s3_flush(struct flb_event_chunk *event_chunk,
                         struct flb_config *config)
 {
     int ret;
+    flb_sds_t chunk;
     struct flb_s3 *ctx = out_context;
 
     if (event_chunk->type == FLB_EVENT_TYPE_BLOBS) {
@@ -4818,13 +4995,18 @@ static void cb_s3_flush(struct flb_event_chunk *event_chunk,
         FLB_OUTPUT_RETURN(FLB_OK);
     }
 
+    chunk = s3_format_event_chunk(ctx, event_chunk, config);
+    if (chunk == NULL) {
+        flb_plg_error(ctx->ins, "Could not marshal msgpack to output string");
+        FLB_OUTPUT_RETURN(FLB_ERROR);
+    }
+
     /*
-     * Keep the store, upload queue and multipart state owned by one callback
-     * until synchronous I/O and cleanup finish. Locking only the lookup or
-     * append leaves returned pointers exposed to another worker's deletion.
+     * Protect store and queue changes. Upload claims let the request paths
+     * release this mutex without exposing their objects to another worker.
      */
     pthread_mutex_lock(&ctx->files_mutex);
-    ret = s3_flush_logs(event_chunk, ctx, config);
+    ret = s3_flush_logs(event_chunk, ctx, chunk);
     pthread_mutex_unlock(&ctx->files_mutex);
 
     FLB_OUTPUT_RETURN(ret);
@@ -4842,6 +5024,7 @@ static int cb_s3_exit(void *data, struct flb_config *config)
         return 0;
     }
 
+    pthread_mutex_lock(&ctx->files_mutex);
     s3_upload_queue_release(ctx);
 
     if (s3_store_has_data(ctx) == FLB_TRUE) {
@@ -4883,6 +5066,7 @@ static int cb_s3_exit(void *data, struct flb_config *config)
     }
 
     s3_store_exit(ctx);
+    pthread_mutex_unlock(&ctx->files_mutex);
     s3_context_destroy(ctx);
 
     return 0;

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -136,6 +136,36 @@ static void s3_claim_end(struct s3_upload_claim *claim)
     mk_list_del(&claim->_head);
 }
 
+/* Providers return owned credentials, but copying their cache must not race refresh. */
+static struct flb_aws_credentials *s3_get_credentials(struct flb_aws_provider *provider)
+{
+    struct flb_s3 *ctx = provider->implementation;
+    struct flb_aws_credentials *credentials;
+
+    pthread_mutex_lock(&ctx->files_mutex);
+    credentials = ctx->provider->provider_vtable->get_credentials(ctx->provider);
+    pthread_mutex_unlock(&ctx->files_mutex);
+
+    return credentials;
+}
+
+static int s3_refresh_credentials(struct flb_aws_provider *provider)
+{
+    struct flb_s3 *ctx = provider->implementation;
+    int ret;
+
+    pthread_mutex_lock(&ctx->files_mutex);
+    ret = ctx->provider->provider_vtable->refresh(ctx->provider);
+    pthread_mutex_unlock(&ctx->files_mutex);
+
+    return ret;
+}
+
+static struct flb_aws_provider_vtable s3_request_provider_vtable = {
+    .get_credentials = s3_get_credentials,
+    .refresh = s3_refresh_credentials
+};
+
 /* Snapshot mutable client state while allowing independent network requests. */
 struct flb_http_client *s3_request(struct flb_s3 *ctx,
                                   int method, const char *uri,
@@ -143,9 +173,14 @@ struct flb_http_client *s3_request(struct flb_s3 *ctx,
                                   struct flb_aws_header *headers, size_t headers_count)
 {
     struct flb_aws_client client;
+    struct flb_aws_provider provider = {0};
     struct flb_http_client *response;
 
+    /* Only credential acquisition/refresh use the shared synchronous provider. */
+    provider.provider_vtable = &s3_request_provider_vtable;
+    provider.implementation = ctx;
     client = *ctx->s3_client;
+    client.provider = &provider;
     pthread_mutex_unlock(&ctx->files_mutex);
     response = client.client_vtable->request(&client, method, uri, body, body_size,
                                              headers, headers_count);
@@ -168,6 +203,7 @@ static struct flb_http_client *s3_blob_request(struct flb_s3 *ctx, int method,
 {
     struct flb_http_client *response;
 
+    /* Blob PutObject enters without files_mutex; multipart callers already own it. */
     pthread_mutex_lock(&ctx->files_mutex);
     response = s3_request(ctx, method, uri, body, body_size, headers, headers_count);
     pthread_mutex_unlock(&ctx->files_mutex);
@@ -3340,7 +3376,7 @@ static struct multipart_upload *create_blob_upload(struct flb_s3 *ctx, const cha
         flb_free(m_upload);
         return NULL;
     }
-    m_upload->request = s3_blob_request;
+    m_upload->request = s3_request;
     m_upload->s3_key = s3_key;
     tmp_sds = flb_sds_create_len(tag, tag_len);
     if (!tmp_sds) {
@@ -3353,17 +3389,19 @@ static struct multipart_upload *create_blob_upload(struct flb_s3 *ctx, const cha
     m_upload->upload_state = MULTIPART_UPLOAD_STATE_NOT_CREATED;
     m_upload->part_number = 1;
     m_upload->init_time = time(NULL);
-    mk_list_add(&m_upload->_head, &ctx->uploads);
+
+    /* Blob uploads are owned by their caller; ctx->uploads is for log uploads. */
 
     /* Update file and increment index value right before request */
     if (ctx->key_fmt_has_seq_index) {
+        pthread_mutex_lock(&ctx->files_mutex);
         ctx->seq_index++;
 
         ret = write_seq_index(ctx->seq_index_file, ctx->seq_index);
         if (ret < 0) {
             ctx->seq_index--;
 
-            mk_list_del(&m_upload->_head);
+            pthread_mutex_unlock(&ctx->files_mutex);
 
             flb_sds_destroy(tmp_sds);
             flb_sds_destroy(s3_key);
@@ -3374,6 +3412,7 @@ static struct multipart_upload *create_blob_upload(struct flb_s3 *ctx, const cha
 
             return NULL;
         }
+        pthread_mutex_unlock(&ctx->files_mutex);
     }
 
     return m_upload;
@@ -3386,7 +3425,6 @@ static int put_blob_object(struct flb_s3 *ctx,
 {
     flb_sds_t s3_key = NULL;
     struct flb_http_client *c = NULL;
-    struct flb_aws_client *s3_client;
     struct flb_aws_header *headers = NULL;
     int len;
     int ret;
@@ -3444,7 +3482,6 @@ static int put_blob_object(struct flb_s3 *ctx,
         }
     }
 
-    s3_client = ctx->s3_client;
     if (s3_plugin_under_test() == FLB_TRUE) {
         c = mock_s3_call("TEST_PUT_OBJECT_ERROR", "PutObject");
     }
@@ -3456,9 +3493,8 @@ static int put_blob_object(struct flb_s3 *ctx,
             return -1;
         }
 
-        c = s3_client->client_vtable->request(s3_client, FLB_HTTP_PUT,
-                                              uri, body, body_size,
-                                              headers, num_headers);
+        c = s3_blob_request(ctx, FLB_HTTP_PUT, uri, body, body_size,
+                              headers, num_headers);
         flb_free(headers);
     }
     if (c) {
@@ -3506,8 +3542,6 @@ static int abort_blob_upload(struct flb_s3 *ctx,
         return -1;
     }
 
-    mk_list_del(&m_upload->_head);
-
     m_upload->upload_id = flb_sds_create(file_remote_id);
 
     if (m_upload->upload_id == NULL) {
@@ -3540,7 +3574,9 @@ static int abort_blob_upload(struct flb_s3 *ctx,
         pre_signed_url = NULL;
     }
 
+    pthread_mutex_lock(&ctx->files_mutex);
     ret = abort_multipart_upload(ctx, m_upload, pre_signed_url);
+    pthread_mutex_unlock(&ctx->files_mutex);
 
     if (pre_signed_url != NULL) {
         flb_sds_destroy(pre_signed_url);
@@ -3748,8 +3784,6 @@ static int cb_s3_upload_blob(struct flb_config *config, void *data)
                 return -1;
             }
 
-            mk_list_del(&m_upload->_head);
-
             m_upload->upload_id = flb_sds_create(file_remote_id);
 
             if (m_upload->upload_id == NULL) {
@@ -3802,7 +3836,9 @@ static int cb_s3_upload_blob(struct flb_config *config, void *data)
                 pre_signed_url = NULL;
             }
 
+            pthread_mutex_lock(&ctx->files_mutex);
             ret = complete_multipart_upload(ctx, m_upload, pre_signed_url);
+            pthread_mutex_unlock(&ctx->files_mutex);
 
             if (pre_signed_url != NULL) {
                 flb_sds_destroy(pre_signed_url);
@@ -4014,8 +4050,6 @@ static int cb_s3_upload_blob(struct flb_config *config, void *data)
             return -1;
         }
 
-        mk_list_del(&m_upload->_head);
-
         if (part_id == 0) {
             if (ctx->authorization_endpoint_url != NULL) {
                 ret = blob_fetch_create_multipart_upload_pre_signed_url(ctx,
@@ -4042,7 +4076,9 @@ static int cb_s3_upload_blob(struct flb_config *config, void *data)
                 pre_signed_url = NULL;
             }
 
+            pthread_mutex_lock(&ctx->files_mutex);
             ret = create_multipart_upload(ctx, m_upload, pre_signed_url);
+            pthread_mutex_unlock(&ctx->files_mutex);
 
             if (pre_signed_url != NULL) {
                 flb_sds_destroy(pre_signed_url);
@@ -4134,7 +4170,9 @@ static int cb_s3_upload_blob(struct flb_config *config, void *data)
             pre_signed_url = NULL;
         }
 
+        pthread_mutex_lock(&ctx->files_mutex);
         ret = upload_part(ctx, m_upload, out_buf, out_size, pre_signed_url);
+        pthread_mutex_unlock(&ctx->files_mutex);
 
         if (pre_signed_url != NULL) {
             flb_sds_destroy(pre_signed_url);
@@ -4749,7 +4787,26 @@ static int process_blob_chunk(struct flb_s3 *ctx, struct flb_event_chunk *event_
 
 static void cb_s3_blob_file_upload(struct flb_config *config, void *out_context)
 {
+    struct flb_s3 *ctx = out_context;
+    struct worker_info *info = FLB_TLS_GET(s3_worker_info);
+
+    /* Blob database selection and completion span several separate operations. */
+    pthread_mutex_lock(&ctx->files_mutex);
+    if (ctx->blob_upload_in_progress) {
+        pthread_mutex_unlock(&ctx->files_mutex);
+        flb_sched_timer_cb_coro_return();
+        return;
+    }
+    ctx->blob_upload_in_progress = FLB_TRUE;
+    pthread_mutex_unlock(&ctx->files_mutex);
+
     cb_s3_upload_blob(config, out_context);
+
+    /* Release ownership on every return path, including failed blob requests. */
+    info->active_upload = FLB_FALSE;
+    pthread_mutex_lock(&ctx->files_mutex);
+    ctx->blob_upload_in_progress = FLB_FALSE;
+    pthread_mutex_unlock(&ctx->files_mutex);
 
     flb_sched_timer_cb_coro_return();
 }

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -120,7 +120,7 @@ struct multipart_upload {
     int upload_errors;
     int complete_errors;
     uint64_t completion_scan_id;
-    /* Requests preserve the caller's store-lock ownership on return. */
+    /* Multipart helpers own files_mutex; requests release/reacquire it for I/O. */
     s3_request_fn *request;
 };
 
@@ -196,6 +196,7 @@ struct flb_s3 {
     int files_mutex_initialized;
     struct mk_list upload_claims;
     uint64_t upload_scan_id;
+    int blob_upload_in_progress;
 
     /*
      * used to track that unset buffers were found on startup that have not

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -79,9 +79,17 @@ struct upload_queue {
 
     int retry_counter;
     time_t upload_time;
+    uint64_t scan_id;
+    int in_flight;
 
     struct mk_list _head;
 };
+
+struct flb_s3;
+
+typedef struct flb_http_client *s3_request_fn(struct flb_s3 *ctx, int method,
+                                            const char *uri, const char *body, size_t body_size,
+                                            struct flb_aws_header *headers, size_t headers_count);
 
 struct multipart_upload {
     flb_sds_t s3_key;
@@ -111,6 +119,9 @@ struct multipart_upload {
     /* see note for retry_limit configuration */
     int upload_errors;
     int complete_errors;
+    uint64_t completion_scan_id;
+    /* Requests preserve the caller's store-lock ownership on return. */
+    s3_request_fn *request;
 };
 
 struct flb_s3 {
@@ -180,15 +191,18 @@ struct flb_s3 {
     struct flb_fstore_stream *stream_upload;  /* multipart upload stream */
     struct flb_fstore_stream *stream_quarantine; /* retry-exhausted stream */
     struct flb_fstore_stream *stream_metadata; /* s3 metadata stream */
-    /* Serializes synchronous log flushes and timers, including chunk deletion. */
+    /* Protects store and upload state; owned requests run outside this mutex. */
     pthread_mutex_t files_mutex;
     int files_mutex_initialized;
+    struct mk_list upload_claims;
+    uint64_t upload_scan_id;
 
     /*
      * used to track that unset buffers were found on startup that have not
      * been sent
      */
     int has_old_buffers;
+    int draining_backlog;
     /* old multipart uploads read on start up */
     int has_old_uploads;
 
@@ -215,6 +229,11 @@ struct flb_s3 {
 
     struct flb_output_instance *ins;
 };
+
+struct flb_http_client *s3_request(struct flb_s3 *ctx,
+                                  int method, const char *uri,
+                                  const char *body, size_t body_size,
+                                  struct flb_aws_header *headers, size_t headers_count);
 
 int upload_part(struct flb_s3 *ctx, struct multipart_upload *m_upload,
                 char *body, size_t body_size, char *pre_signed_url);

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -180,6 +180,7 @@ struct flb_s3 {
     struct flb_fstore_stream *stream_upload;  /* multipart upload stream */
     struct flb_fstore_stream *stream_quarantine; /* retry-exhausted stream */
     struct flb_fstore_stream *stream_metadata; /* s3 metadata stream */
+    /* Serializes synchronous log flushes and timers, including chunk deletion. */
     pthread_mutex_t files_mutex;
     int files_mutex_initialized;
 

--- a/plugins/out_s3/s3_multipart.c
+++ b/plugins/out_s3/s3_multipart.c
@@ -205,6 +205,8 @@ static struct multipart_upload *upload_from_file(struct flb_s3 *ctx,
     m_upload->init_time = time(NULL);
     m_upload->upload_state = MULTIPART_UPLOAD_STATE_COMPLETE_IN_PROGRESS;
 
+    m_upload->request = s3_request;
+
     ret = upload_data_from_key(m_upload, fsf->meta_buf);
     if (ret < 0) {
         flb_plg_error(ctx->ins, "Could not extract upload data from: %s",
@@ -413,7 +415,6 @@ int complete_multipart_upload(struct flb_s3 *ctx,
     flb_sds_t tmp;
     int ret;
     struct flb_http_client *c = NULL;
-    struct flb_aws_client *s3_client;
 
     if (!m_upload->upload_id) {
         flb_plg_error(ctx->ins, "Cannot complete multipart upload for key %s: "
@@ -448,12 +449,11 @@ int complete_multipart_upload(struct flb_s3 *ctx,
         return -1;
     }
 
-    s3_client = ctx->s3_client;
     if (s3_plugin_under_test() == FLB_TRUE) {
         c = mock_s3_call("TEST_COMPLETE_MULTIPART_UPLOAD_ERROR", "CompleteMultipartUpload");
     }
     else {
-        c = s3_client->client_vtable->request(s3_client, FLB_HTTP_POST,
+        c = m_upload->request(ctx, FLB_HTTP_POST,
                                               uri, body, size,
                                               NULL, 0);
     }
@@ -491,7 +491,6 @@ int abort_multipart_upload(struct flb_s3 *ctx,
     flb_sds_t uri = NULL;
     flb_sds_t tmp;
     struct flb_http_client *c = NULL;
-    struct flb_aws_client *s3_client;
 
     if (!m_upload->upload_id) {
         flb_plg_error(ctx->ins, "Cannot complete multipart upload for key %s: "
@@ -520,12 +519,11 @@ int abort_multipart_upload(struct flb_s3 *ctx,
     }
     uri = tmp;
 
-    s3_client = ctx->s3_client;
     if (s3_plugin_under_test() == FLB_TRUE) {
         c = mock_s3_call("TEST_ABORT_MULTIPART_UPLOAD_ERROR", "AbortMultipartUpload");
     }
     else {
-        c = s3_client->client_vtable->request(s3_client, FLB_HTTP_DELETE,
+        c = m_upload->request(ctx, FLB_HTTP_DELETE,
                                               uri, NULL, 0,
                                               NULL, 0);
     }
@@ -563,7 +561,6 @@ int create_multipart_upload(struct flb_s3 *ctx,
     flb_sds_t uri = NULL;
     flb_sds_t tmp;
     struct flb_http_client *c = NULL;
-    struct flb_aws_client *s3_client;
     struct flb_aws_header *headers = NULL;
     int num_headers = 0;
     int ret;
@@ -587,7 +584,6 @@ int create_multipart_upload(struct flb_s3 *ctx,
     }
     uri = tmp;
 
-    s3_client = ctx->s3_client;
     if (s3_plugin_under_test() == FLB_TRUE) {
         c = mock_s3_call("TEST_CREATE_MULTIPART_UPLOAD_ERROR", "CreateMultipartUpload");
     }
@@ -598,7 +594,7 @@ int create_multipart_upload(struct flb_s3 *ctx,
             flb_sds_destroy(uri);
             return -1;
         }
-        c = s3_client->client_vtable->request(s3_client, FLB_HTTP_POST,
+        c = m_upload->request(ctx, FLB_HTTP_POST,
                                               uri, NULL, 0, headers, num_headers);
         if (headers) {
            flb_free(headers);
@@ -690,7 +686,6 @@ int upload_part(struct flb_s3 *ctx, struct multipart_upload *m_upload,
     flb_sds_t tmp;
     int ret;
     struct flb_http_client *c = NULL;
-    struct flb_aws_client *s3_client;
     struct flb_aws_header *headers = NULL;
     int num_headers = 0;
     char body_md5[25];
@@ -740,12 +735,11 @@ int upload_part(struct flb_s3 *ctx, struct multipart_upload *m_upload,
         headers[0].val_len = strlen(body_md5);
     }
 
-    s3_client = ctx->s3_client;
     if (s3_plugin_under_test() == FLB_TRUE) {
         c = mock_s3_call("TEST_UPLOAD_PART_ERROR", "UploadPart");
     }
     else {
-        c = s3_client->client_vtable->request(s3_client, FLB_HTTP_PUT,
+        c = m_upload->request(ctx, FLB_HTTP_PUT,
                                               uri, body, body_size,
                                               headers, num_headers);
     }

--- a/plugins/out_s3/s3_store.c
+++ b/plugins/out_s3/s3_store.c
@@ -316,6 +316,7 @@ int s3_store_buffer_put(struct flb_s3 *ctx, struct s3_file *s3_file,
             goto done;
         }
         s3_file->fsf = fsf;
+        s3_file->upload_scan_id = ctx->upload_scan_id;
         s3_file->first_log_time = file_first_log_time;
         s3_file->create_time = time(NULL);
 

--- a/plugins/out_s3/s3_store.c
+++ b/plugins/out_s3/s3_store.c
@@ -206,8 +206,6 @@ struct s3_file *s3_store_file_get(struct flb_s3 *ctx, const char *tag,
     struct flb_fstore_file *fsf = NULL;
     struct s3_file *s3_file;
 
-    pthread_mutex_lock(&ctx->files_mutex);
-
     /*
      * Based in the current ctx->stream_name, locate a candidate file to
      * store the incoming data using as a lookup pattern the content Tag.
@@ -245,12 +243,10 @@ struct s3_file *s3_store_file_get(struct flb_s3 *ctx, const char *tag,
     }
 
     if (!fsf) {
-        pthread_mutex_unlock(&ctx->files_mutex);
         return NULL;
     }
 
     s3_file = fsf->data;
-    pthread_mutex_unlock(&ctx->files_mutex);
 
     return s3_file;
 }
@@ -269,8 +265,6 @@ int s3_store_buffer_put(struct flb_s3 *ctx, struct s3_file *s3_file,
     uint64_t new_buffer_size;
 
     result = -1;
-    pthread_mutex_lock(&ctx->files_mutex);
-
     ret = buffer_size_reserve(ctx, bytes, &current_buffer_size,
                               &new_buffer_size);
     if (ret < 0) {
@@ -357,7 +351,6 @@ int s3_store_buffer_put(struct flb_s3 *ctx, struct s3_file *s3_file,
     result = 0;
 
 done:
-    pthread_mutex_unlock(&ctx->files_mutex);
     return result;
 }
 

--- a/plugins/out_s3/s3_store.h
+++ b/plugins/out_s3/s3_store.h
@@ -35,6 +35,10 @@ struct s3_file {
 
 #define S3_STORE_QUARANTINE_FULL -2
 
+/*
+ * Runtime callers must hold ctx->files_mutex across store operations and use
+ * of returned pointers. Initialization and exit run without competing workers.
+ */
 int s3_store_buffer_put(struct flb_s3 *ctx, struct s3_file *s3_file,
                         const char *tag, int tag_len,
                         char *data, size_t bytes,

--- a/plugins/out_s3/s3_store.h
+++ b/plugins/out_s3/s3_store.h
@@ -26,6 +26,7 @@
 struct s3_file {
     int locked;                      /* locked chunk is busy, cannot write to it */
     int failures;                    /* delivery failures */
+    uint64_t upload_scan_id;
     uint64_t size;                   /* file size */
     time_t create_time;              /* creation time */
     time_t first_log_time;           /* first log time */
@@ -37,7 +38,8 @@ struct s3_file {
 
 /*
  * Runtime callers must hold ctx->files_mutex across store operations and use
- * of returned pointers. Initialization and exit run without competing workers.
+ * of returned pointers, except owned chunks while uploading an independent
+ * payload. Initialization and exit run without competing workers.
  */
 int s3_store_buffer_put(struct flb_s3 *ctx, struct s3_file *s3_file,
                         const char *tag, int tag_len,

--- a/tests/integration/scenarios/out_s3/tests/test_out_s3_001.py
+++ b/tests/integration/scenarios/out_s3/tests/test_out_s3_001.py
@@ -4,9 +4,11 @@ import os
 import glob
 import time
 import shutil
+from pathlib import Path
 
 import requests
 import pytest
+import yaml
 from google.protobuf import json_format
 from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceRequest
 from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceRequest
@@ -19,7 +21,9 @@ from utils.test_service import FluentBitTestService
 
 
 class Service:
-    def __init__(self, config_file):
+    def __init__(self, config_file, *, put_status=200, put_delay=0):
+        self.put_status = put_status
+        self.put_delay = put_delay
         self.config_file = os.path.abspath(
             os.path.join(os.path.dirname(__file__), "../config", config_file)
         )
@@ -39,6 +43,8 @@ class Service:
     def _start_receiver(self, service):
         self.s3_port = service.allocate_port_env("TEST_SUITE_HTTP_PORT")
         s3_server_run(self.s3_port)
+        data_storage["put_status"] = self.put_status
+        data_storage["put_delay"] = self.put_delay
 
     def _stop_receiver(self, service):
         s3_server_stop()
@@ -257,6 +263,123 @@ def test_out_s3_default_retry_exhausted_action_quarantines_file():
     service.stop()
 
     assert len(files) > 0
+
+
+@pytest.mark.parametrize("action", ["quarantine", "delete", "quarantine_full"])
+@pytest.mark.parametrize("preserve_ordering", [True, False])
+def test_out_s3_multiworker_retry_exhaustion_survives_and_recovers(tmp_path, action, preserve_ordering):
+    config = {
+        "service": {
+            "flush": 0.1,
+            "grace": 1,
+            "log_level": "info",
+            "http_server": "on",
+            "http_port": "${FLUENT_BIT_HTTP_MONITORING_PORT}",
+            "storage.path": str(tmp_path / "engine"),
+        },
+        "pipeline": {
+            "inputs": [
+                {"name": "dummy", "tag": tag, "rate": 20,
+                 "storage.type": "filesystem",
+                 "dummy": json.dumps({"message": "retry exhaustion", "source": tag})}
+                for tag in ["journal", "app"]
+            ],
+            "outputs": [
+                {
+                    "name": "s3",
+                    "match": "*",
+                    "workers": 4,
+                    "bucket": bucket,
+                    "region": "us-east-1",
+                    "endpoint": "http://127.0.0.1:${TEST_SUITE_HTTP_PORT}",
+                    "use_put_object": True,
+                    "preserve_data_ordering": preserve_ordering,
+                    "retry_limit": 1,
+                    "retry_exhausted_action": "delete" if action == "delete" else "quarantine",
+                    "quarantine_dir_limit_size": "1" if action == "quarantine_full" else "0",
+                    "total_file_size": "1M",
+                    "upload_timeout": "1s",
+                    "compression": "gzip",
+                    "s3_key_format": "/$TAG/$UUID.gz",
+                    "store_dir": str(tmp_path / bucket),
+                    "store_dir_limit_size": "20M",
+                }
+                for bucket in ["first-bucket", "second-bucket"]
+            ],
+        },
+    }
+    config_file = tmp_path / "retry_exhaustion.yaml"
+
+    if not preserve_ordering:
+        # Leave active buffers behind to exercise put_all_chunks during restart.
+        for input_config in config["pipeline"]["inputs"]:
+            input_config["samples"] = 1
+        for output_config in config["pipeline"]["outputs"]:
+            output_config["upload_timeout"] = "60s"
+        config_file.write_text(yaml.safe_dump(config))
+        service = Service(str(config_file), put_status=403)
+        service.start()
+        service.service.wait_for_condition(
+            lambda: all(len(list((tmp_path / bucket).glob("**/20*/*"))) >= 2
+                        for bucket in ["first-bucket", "second-bucket"]),
+            timeout=30, description="buffers for restart",
+        )
+        process = service.service.flb.process
+        service.stop()
+        assert process.returncode == 0
+        for input_config in config["pipeline"]["inputs"]:
+            del input_config["samples"]
+        for output_config in config["pipeline"]["outputs"]:
+            output_config["upload_timeout"] = "1s"
+
+    config_file.write_text(yaml.safe_dump(config))
+    service = Service(str(config_file), put_status=403, put_delay=0.1)
+    service.start()
+
+    def cleanup_completed():
+        assert service.service.flb.process.poll() is None, "Fluent Bit crashed during retry exhaustion"
+        logs = Path(service.service.flb.log_file).read_text()
+        if action == "quarantine":
+            return all(len(list((tmp_path / bucket).glob("**/quarantine/*"))) >= 2
+                       for bucket in ["first-bucket", "second-bucket"])
+        if action == "quarantine_full":
+            marker = "quarantine limit reached, deleting retry-exhausted chunk"
+        else:
+            marker = "will not retry"
+        return all(sum(f"[output:s3:s3.{index}]" in line and marker in line
+                       for line in logs.splitlines()) >= 2 for index in [0, 1])
+
+    service.service.wait_for_condition(
+        cleanup_completed, timeout=60, interval=0.1, description="retry-exhausted chunks in both outputs"
+    )
+    # A successful upload after exhaustion proves workers can still use the store.
+    data_storage["put_status"] = 200
+    request_count = len(data_storage["requests"])
+
+    def recovered():
+        assert service.service.flb.process.poll() is None, "Fluent Bit crashed after retry exhaustion"
+        return all(any(request["path"].startswith(f"/{bucket}/") and request.get("status") == 200
+                       for request in data_storage["requests"][request_count:])
+                   for bucket in ["first-bucket", "second-bucket"])
+
+    service.service.wait_for_condition(
+        recovered,
+        timeout=30, description="uploads after permissions recover",
+    )
+    process = service.service.flb.process
+    service.stop()
+    assert process.returncode == 0
+    # Read only after shutdown so no quarantine file is still being written.
+    quarantined = {path: path.read_bytes() for path in tmp_path.glob("**/quarantine/*") if path.is_file()}
+
+    # Restart using the same buffers, including quarantined files.
+    service = Service(str(config_file))
+    service.start()
+    service.wait_for_request()
+    process = service.service.flb.process
+    service.stop()
+    assert process.returncode == 0
+    assert all(path.read_bytes() == content for path, content in quarantined.items())
 
 
 def test_out_s3_format_arrow_uploads_feather_with_zstd():

--- a/tests/integration/scenarios/out_s3/tests/test_out_s3_001.py
+++ b/tests/integration/scenarios/out_s3/tests/test_out_s3_001.py
@@ -1,10 +1,13 @@
 import gzip
+import hashlib
+import hmac
 import json
 import os
 import glob
 import time
 import shutil
 from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
 
 import requests
 import pytest
@@ -14,16 +17,19 @@ from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsSer
 from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceRequest
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
 
-from server.s3_server import data_storage, s3_server_run, s3_server_stop
+from server.s3_server import TaggedUploadBarrier, data_storage, s3_server_run, s3_server_stop
 from utils.data_utils import read_json_file
 from utils.fluent_bit_manager import FluentBitStartupError
 from utils.test_service import FluentBitTestService
 
 
 class Service:
-    def __init__(self, config_file, *, put_status=200, put_delay=0):
+    def __init__(self, config_file, *, put_status=200, put_delay=0,
+                 upload_barrier=None, shutdown_timeout=None, credential_mode=None):
         self.put_status = put_status
         self.put_delay = put_delay
+        self.upload_barrier = upload_barrier
+        self.credential_mode = credential_mode
         self.config_file = os.path.abspath(
             os.path.join(os.path.dirname(__file__), "../config", config_file)
         )
@@ -32,12 +38,13 @@ class Service:
             data_storage=data_storage,
             data_keys=["requests"],
             extra_env={
-                "AWS_ACCESS_KEY_ID": "test-access-key",
-                "AWS_SECRET_ACCESS_KEY": "test-secret-key",
+                "AWS_ACCESS_KEY_ID": "" if credential_mode else "test-access-key",
+                "AWS_SECRET_ACCESS_KEY": "" if credential_mode else "test-secret-key",
                 "AWS_EC2_METADATA_DISABLED": "true",
             },
             pre_start=self._start_receiver,
             post_stop=self._stop_receiver,
+            shutdown_timeout=shutdown_timeout,
         )
 
     def _start_receiver(self, service):
@@ -45,6 +52,14 @@ class Service:
         s3_server_run(self.s3_port)
         data_storage["put_status"] = self.put_status
         data_storage["put_delay"] = self.put_delay
+        data_storage["upload_barrier"] = self.upload_barrier
+        data_storage["credential_mode"] = self.credential_mode
+        if self.credential_mode:
+            service._set_env("AWS_CONTAINER_CREDENTIALS_FULL_URI", f"http://127.0.0.1:{self.s3_port}/credentials")
+            service._set_env("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "")
+            service._set_env("AWS_CONFIG_FILE", os.devnull)
+            service._set_env("AWS_SHARED_CREDENTIALS_FILE", os.devnull)
+            service._set_env("AWS_WEB_IDENTITY_TOKEN_FILE", "")
 
     def _stop_receiver(self, service):
         s3_server_stop()
@@ -382,14 +397,15 @@ def test_out_s3_multiworker_retry_exhaustion_survives_and_recovers(tmp_path, act
     assert all(path.read_bytes() == content for path, content in quarantined.items())
 
 
-@pytest.mark.parametrize("mode", ["put_unordered", "put_ordered", "put_index", "multipart"])
+@pytest.mark.parametrize("mode", ["put_unordered", "put_ordered", "put_index", "multipart",
+                                  "put_refresh", "put_expiring"])
 def test_out_s3_workers_upload_independent_tags_concurrently(tmp_path, mode):
     multipart = mode == "multipart"
     tags = ["first", "second"]
     config = {
         "service": {
             "flush": 0.1,
-            "grace": 2,
+            "grace": 5,
             "log_level": "info",
             "http_server": "on",
             "http_port": "${FLUENT_BIT_HTTP_MONITORING_PORT}",
@@ -422,7 +438,10 @@ def test_out_s3_workers_upload_independent_tags_concurrently(tmp_path, mode):
     }
     config_file = tmp_path / "concurrent_uploads.yaml"
     config_file.write_text(yaml.safe_dump(config))
-    service = Service(str(config_file), put_delay=0.4)
+    barrier = None if mode == "put_index" else TaggedUploadBarrier(tags)
+    credential_mode = {"put_refresh": "refresh", "put_expiring": "expiring"}.get(mode)
+    service = Service(str(config_file), put_delay=0.4, upload_barrier=barrier,
+                      shutdown_timeout=30, credential_mode=credential_mode)
     service.start()
 
     def uploads_complete():
@@ -447,13 +466,132 @@ def test_out_s3_workers_upload_independent_tags_concurrently(tmp_path, mode):
     if mode == "put_index":
         assert not overlaps, "$INDEX uploads must preserve global ordering"
     else:
+        paired = [request for request in uploads if request.get("barrier_passed") is not None]
+        assert len(paired) == len(tags)
+        assert all(request["barrier_passed"] for request in paired), "Tagged uploads did not meet at barrier"
         assert overlaps, "Independent tags were serialized despite four output workers"
         for first, second in overlaps:
             assert first["path"].split("/")[2] != second["path"].split("/")[2]
     if multipart:
-        assert all("partNumber=" in request["path"] for request in uploads)
-        assert sum(request["method"] == "POST" and "uploadId=" in request["path"]
-                   for request in data_storage["requests"]) == len(tags)
+        initiations = [request for request in data_storage["requests"] if "upload_id" in request]
+        assert len(initiations) == len(tags)
+        upload_ids = {urlsplit(request["path"]).path: request["upload_id"] for request in initiations}
+        assert len(set(upload_ids.values())) == len(tags)
+        completions = []
+        for request in data_storage["requests"]:
+            parsed = urlsplit(request["path"])
+            query = parse_qs(parsed.query)
+            if request["method"] == "PUT" or "uploadId" in query:
+                assert request["status"] == 200
+                assert query["uploadId"] == [upload_ids[parsed.path]]
+                if request["method"] == "PUT":
+                    assert "partNumber" in query
+                    tag = parsed.path.split("/")[2]
+                    assert all(json.loads(line)["source"] == tag for line in request["body"].splitlines())
+                else:
+                    completions.append(parsed.path)
+        assert sorted(completions) == sorted(upload_ids)
+    if credential_mode:
+        assert data_storage["credential_requests"] > 1
+        for request in data_storage["requests"]:
+            _assert_rotating_credentials_signature(request)
+        if credential_mode == "refresh":
+            assert data_storage["auth_failures"] == set(tags)
+            assert sum(request["status"] == 403 for request in data_storage["requests"]) == len(tags)
+
+
+def _assert_rotating_credentials_signature(request):
+    headers = {key.lower(): value for key, value in request["headers"].items()}
+    algorithm, fields = headers["authorization"].split(" ", 1)
+    fields = dict(field.strip().split("=", 1) for field in fields.split(","))
+    access_key, scope = fields["Credential"].split("/", 1)
+    generation = access_key.removeprefix("test-access-")
+    assert headers["x-amz-security-token"] == f"test-token-{generation}"
+    signed_headers = fields["SignedHeaders"]
+    canonical_headers = "".join(f"{key}:{' '.join(headers[key].split())}\n"
+                                for key in signed_headers.split(";"))
+    parsed = urlsplit(request["path"])
+    assert not parsed.query
+    payload_hash = hashlib.sha256(request["body"]).hexdigest()
+    canonical = "\n".join([request["method"], parsed.path, "", canonical_headers,
+                            signed_headers, payload_hash])
+    string_to_sign = "\n".join([algorithm, headers["x-amz-date"], scope,
+                                 hashlib.sha256(canonical.encode()).hexdigest()])
+    key = f"AWS4test-secret-{generation}".encode()
+    for component in scope.split("/"):
+        key = hmac.new(key, component.encode(), hashlib.sha256).digest()
+    assert fields["Signature"] == hmac.new(key, string_to_sign.encode(), hashlib.sha256).hexdigest()
+
+
+def test_out_s3_blob_and_log_uploads_keep_separate_ownership(tmp_path):
+    small_blob = tmp_path / "small.bin"
+    large_blob = tmp_path / "large.bin"
+    small_blob.write_bytes(b"small blob")
+    large_blob.write_bytes(b"b" * 6000000)
+    config = {
+        "service": {
+            "flush": 0.1, "grace": 5, "log_level": "info",
+            "http_server": "on", "http_port": "${FLUENT_BIT_HTTP_MONITORING_PORT}",
+        },
+        "pipeline": {
+            "inputs": [
+                {"name": "dummy", "tag": "logs", "rate": 10,
+                 "dummy": '{"message":"concurrent log"}'},
+                {"name": "blob", "tag": "blobs", "path": str(tmp_path / "*.bin"),
+                 "database_file": str(tmp_path / "input.db"), "scan_refresh_interval": "1s"},
+            ],
+            "outputs": [{
+                "name": "s3", "match": "*", "workers": 4,
+                "bucket": "mixed-bucket", "region": "us-east-1",
+                "endpoint": "http://127.0.0.1:${TEST_SUITE_HTTP_PORT}",
+                "use_put_object": True, "total_file_size": "1048576",
+                "upload_timeout": "1s", "s3_key_format": "/$TAG/$UUID",
+                "store_dir": str(tmp_path / "store"),
+                "blob_database_file": str(tmp_path / "output.db"),
+                "part_size": "5242880", "upload_parts_timeout": "1s",
+            }],
+        },
+    }
+    config_file = tmp_path / "mixed_uploads.yaml"
+    config_file.write_text(yaml.safe_dump(config))
+    service = Service(str(config_file), put_delay=0.2, shutdown_timeout=30)
+    service.start()
+
+    def uploads_complete():
+        assert service.service.flb.process.poll() is None
+        requests_seen = data_storage["requests"]
+        return (any(request["method"] == "POST" and "uploadId=" in request["path"]
+                    and request.get("status") == 200 for request in requests_seen)
+                and any(request["method"] == "PUT" and request["body"] == b"small blob"
+                        and request.get("status") == 200 for request in requests_seen)
+                and any("/logs/" in request["path"] and request.get("status") == 200
+                        for request in requests_seen))
+
+    service.service.wait_for_condition(uploads_complete, timeout=60,
+                                       description="blob multipart completion alongside log uploads")
+    process = service.service.flb.process
+    service.stop()
+    assert process.returncode == 0
+    initiations = [request for request in data_storage["requests"] if "upload_id" in request]
+    assert len(initiations) == 1
+    upload_id = initiations[0]["upload_id"]
+    parts = [request for request in data_storage["requests"] if "partNumber=" in request["path"]]
+    assert len(parts) == 2
+    part_bodies = {}
+    for request in parts:
+        part_number = int(parse_qs(urlsplit(request["path"]).query)["partNumber"][0])
+        assert part_number not in part_bodies
+        part_bodies[part_number] = request["body"]
+    assert sorted(part_bodies) == [1, 2]
+    assert b"".join(part_bodies[number] for number in sorted(part_bodies)) == large_blob.read_bytes()
+    completions = [request for request in data_storage["requests"]
+                   if request["method"] == "POST" and "uploadId=" in request["path"]]
+    assert len(completions) == 1
+    for request in data_storage["requests"]:
+        query = parse_qs(urlsplit(request["path"]).query)
+        if "uploadId" in query:
+            assert query["uploadId"] == [upload_id]
+            assert request["status"] == 200
 
 
 def test_out_s3_format_arrow_uploads_feather_with_zstd():

--- a/tests/integration/scenarios/out_s3/tests/test_out_s3_001.py
+++ b/tests/integration/scenarios/out_s3/tests/test_out_s3_001.py
@@ -410,8 +410,9 @@ def test_out_s3_workers_upload_independent_tags_concurrently(tmp_path, mode):
                 "endpoint": "http://127.0.0.1:${TEST_SUITE_HTTP_PORT}",
                 "use_put_object": not multipart,
                 "preserve_data_ordering": mode != "put_unordered",
-                "total_file_size": "10M" if multipart else "1M",
-                "upload_chunk_size": "5M" if multipart else "512K",
+                # Use exact bytes: S3's multipart minimum is 5 MiB, not 5 MB.
+                "total_file_size": "10485760" if multipart else "1048576",
+                "upload_chunk_size": "5242880" if multipart else "524288",
                 "upload_timeout": "120s" if multipart else "1s",
                 "compression": "none" if multipart else "gzip",
                 "s3_key_format": "/$TAG/$INDEX-$UUID" if mode == "put_index" else "/$TAG/$UUID",

--- a/tests/integration/scenarios/out_s3/tests/test_out_s3_001.py
+++ b/tests/integration/scenarios/out_s3/tests/test_out_s3_001.py
@@ -382,6 +382,79 @@ def test_out_s3_multiworker_retry_exhaustion_survives_and_recovers(tmp_path, act
     assert all(path.read_bytes() == content for path, content in quarantined.items())
 
 
+@pytest.mark.parametrize("mode", ["put_unordered", "put_ordered", "put_index", "multipart"])
+def test_out_s3_workers_upload_independent_tags_concurrently(tmp_path, mode):
+    multipart = mode == "multipart"
+    tags = ["first", "second"]
+    config = {
+        "service": {
+            "flush": 0.1,
+            "grace": 2,
+            "log_level": "info",
+            "http_server": "on",
+            "http_port": "${FLUENT_BIT_HTTP_MONITORING_PORT}",
+        },
+        "pipeline": {
+            "inputs": [
+                {"name": "dummy", "tag": tag, "rate": 10,
+                 "samples": 2 if multipart else 0,
+                 "dummy": json.dumps({"source": tag, "message": "x" * (3000000 if multipart else 100)})}
+                for tag in tags
+            ],
+            "outputs": [{
+                "name": "s3",
+                "match": "*",
+                "workers": 4,
+                "bucket": "concurrent-bucket",
+                "region": "us-east-1",
+                "endpoint": "http://127.0.0.1:${TEST_SUITE_HTTP_PORT}",
+                "use_put_object": not multipart,
+                "preserve_data_ordering": mode != "put_unordered",
+                "total_file_size": "10M" if multipart else "1M",
+                "upload_chunk_size": "5M" if multipart else "512K",
+                "upload_timeout": "120s" if multipart else "1s",
+                "compression": "none" if multipart else "gzip",
+                "s3_key_format": "/$TAG/$INDEX-$UUID" if mode == "put_index" else "/$TAG/$UUID",
+                "store_dir": str(tmp_path / "store"),
+            }],
+        },
+    }
+    config_file = tmp_path / "concurrent_uploads.yaml"
+    config_file.write_text(yaml.safe_dump(config))
+    service = Service(str(config_file), put_delay=0.4)
+    service.start()
+
+    def uploads_complete():
+        assert service.service.flb.process.poll() is None
+        uploads = [request for request in data_storage["requests"]
+                   if request["method"] == "PUT" and request.get("status") == 200]
+        expected = 1 if multipart else 2
+        if all(sum(f"/{tag}/" in request["path"] for request in uploads) >= expected for tag in tags):
+            return uploads
+        return None
+
+    uploads = service.service.wait_for_condition(
+        uploads_complete, timeout=60, interval=0.1, description="uploads from both tags",
+    )
+    process = service.service.flb.process
+    service.stop()
+    assert process.returncode == 0
+
+    overlaps = [(first, second) for index, first in enumerate(uploads)
+                for second in uploads[index + 1:]
+                if max(first["started"], second["started"]) < min(first["finished"], second["finished"])]
+    if mode == "put_index":
+        assert not overlaps, "$INDEX uploads must preserve global ordering"
+    else:
+        assert overlaps, "Independent tags were serialized despite four output workers"
+        for first, second in overlaps:
+            assert first["path"].split("/")[2] != second["path"].split("/")[2]
+    if multipart:
+        assert all("partNumber=" in request["path"] for request in uploads)
+        assert sum(request["method"] == "POST" and "uploadId=" in request["path"]
+                   for request in data_storage["requests"]) == len(tags)
+
+
 def test_out_s3_format_arrow_uploads_feather_with_zstd():
     service = Service("out_s3_arrow.yaml")
     _start_or_skip_unsupported_columnar_format(service, "requires arrow-glib")

--- a/tests/integration/src/server/s3_server.py
+++ b/tests/integration/src/server/s3_server.py
@@ -16,6 +16,7 @@
 
 import logging
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 
@@ -31,6 +32,8 @@ server_instance = None
 
 def reset_s3_server_state():
     data_storage["requests"] = []
+    data_storage["put_status"] = 200
+    data_storage["put_delay"] = 0
 
 
 class _S3RequestHandler(BaseHTTPRequestHandler):
@@ -40,21 +43,29 @@ class _S3RequestHandler(BaseHTTPRequestHandler):
     def _record_request(self):
         length = int(self.headers.get("Content-Length", "0"))
         body = self.rfile.read(length) if length > 0 else b""
-        data_storage["requests"].append(
-            {
-                "method": self.command,
-                "path": self.path,
-                "headers": dict(self.headers),
-                "body": body,
-            }
-        )
+        request = {
+            "method": self.command,
+            "path": self.path,
+            "headers": dict(self.headers),
+            "body": body,
+        }
+        data_storage["requests"].append(request)
+        return request
 
     def do_PUT(self):
-        self._record_request()
-        self.send_response(200)
+        request = self._record_request()
+        status = data_storage["put_status"]
+        time.sleep(data_storage["put_delay"])
+        body = b""
+        if status == 403:
+            body = b"<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>"
+        self.send_response(status)
         self.send_header("ETag", '"fake-s3-etag"')
-        self.send_header("Content-Length", "0")
+        self.send_header("Content-Length", str(len(body)))
         self.end_headers()
+        if body:
+            self.wfile.write(body)
+        request["status"] = status
 
     def do_POST(self):
         self._record_request()

--- a/tests/integration/src/server/s3_server.py
+++ b/tests/integration/src/server/s3_server.py
@@ -15,9 +15,13 @@
 #  limitations under the License.
 
 import logging
+import json
+from datetime import datetime, timedelta, timezone
 import threading
 import time
+import uuid
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlsplit
 
 
 logger = logging.getLogger(__name__)
@@ -30,10 +34,36 @@ server_thread = None
 server_instance = None
 
 
+class TaggedUploadBarrier:
+    """Hold the first PUT for each tag until all expected tags are in flight."""
+
+    def __init__(self, tags, timeout=15):
+        self.tags = set(tags)
+        self.seen = set()
+        self.lock = threading.Lock()
+        self.barrier = threading.Barrier(len(self.tags), timeout=timeout)
+
+    def wait(self, tag):
+        with self.lock:
+            if tag not in self.tags or tag in self.seen:
+                return None
+            self.seen.add(tag)
+        try:
+            self.barrier.wait()
+            return True
+        except threading.BrokenBarrierError:
+            return False
+
+
 def reset_s3_server_state():
     data_storage["requests"] = []
     data_storage["put_status"] = 200
     data_storage["put_delay"] = 0
+    data_storage["upload_barrier"] = None
+    data_storage["credential_mode"] = None
+    data_storage["credential_requests"] = 0
+    data_storage["auth_failures"] = set()
+    data_storage["state_lock"] = threading.Lock()
 
 
 class _S3RequestHandler(BaseHTTPRequestHandler):
@@ -41,6 +71,7 @@ class _S3RequestHandler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
     def _record_request(self):
+        started = time.monotonic()
         length = int(self.headers.get("Content-Length", "0"))
         body = self.rfile.read(length) if length > 0 else b""
         request = {
@@ -48,7 +79,7 @@ class _S3RequestHandler(BaseHTTPRequestHandler):
             "path": self.path,
             "headers": dict(self.headers),
             "body": body,
-            "started": time.monotonic(),
+            "started": started,
         }
         data_storage["requests"].append(request)
         return request
@@ -56,6 +87,14 @@ class _S3RequestHandler(BaseHTTPRequestHandler):
     def do_PUT(self):
         request = self._record_request()
         status = data_storage["put_status"]
+        tag = urlsplit(self.path).path.split("/")[2]
+        with data_storage["state_lock"]:
+            if data_storage["credential_mode"] == "refresh" and tag not in data_storage["auth_failures"]:
+                data_storage["auth_failures"].add(tag)
+                status = 403
+        barrier = data_storage["upload_barrier"]
+        if barrier is not None and status == 200:
+            request["barrier_passed"] = barrier.wait(tag)
         time.sleep(data_storage["put_delay"])
         body = b""
         if status == 403:
@@ -73,8 +112,11 @@ class _S3RequestHandler(BaseHTTPRequestHandler):
         request = self._record_request()
         time.sleep(data_storage["put_delay"])
         body = b""
-        if "uploads=" in self.path:
-            body = b"<InitiateMultipartUploadResult><UploadId>test-upload</UploadId></InitiateMultipartUploadResult>"
+        if "uploads" in parse_qs(urlsplit(self.path).query, keep_blank_values=True):
+            request["upload_id"] = uuid.uuid4().hex
+            body = ("<InitiateMultipartUploadResult><UploadId>"
+                    f"{request['upload_id']}"
+                    "</UploadId></InitiateMultipartUploadResult>").encode()
         request["finished"] = time.monotonic()
         self.send_response(200)
         self.send_header("Content-Length", str(len(body)))
@@ -84,6 +126,27 @@ class _S3RequestHandler(BaseHTTPRequestHandler):
         request["status"] = 200
 
     def do_GET(self):
+        if self.path == "/credentials":
+            with data_storage["state_lock"]:
+                data_storage["credential_requests"] += 1
+                generation = data_storage["credential_requests"]
+            # A 30-second lifetime falls inside the provider's refresh window.
+            lifetime = 30 if data_storage["credential_mode"] == "expiring" else 3600
+            expiration = datetime.now(timezone.utc) + timedelta(seconds=lifetime)
+            body = json.dumps({
+                "AccessKeyId": f"test-access-{generation}",
+                "SecretAccessKey": f"test-secret-{generation}",
+                "Token": f"test-token-{generation}",
+                "Expiration": expiration.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }).encode()
+            time.sleep(0.1)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
         if self.path == "/ping":
             self.send_response(200)
             self.send_header("Content-Type", "application/json")

--- a/tests/integration/src/server/s3_server.py
+++ b/tests/integration/src/server/s3_server.py
@@ -48,6 +48,7 @@ class _S3RequestHandler(BaseHTTPRequestHandler):
             "path": self.path,
             "headers": dict(self.headers),
             "body": body,
+            "started": time.monotonic(),
         }
         data_storage["requests"].append(request)
         return request
@@ -59,6 +60,7 @@ class _S3RequestHandler(BaseHTTPRequestHandler):
         body = b""
         if status == 403:
             body = b"<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>"
+        request["finished"] = time.monotonic()
         self.send_response(status)
         self.send_header("ETag", '"fake-s3-etag"')
         self.send_header("Content-Length", str(len(body)))
@@ -68,10 +70,18 @@ class _S3RequestHandler(BaseHTTPRequestHandler):
         request["status"] = status
 
     def do_POST(self):
-        self._record_request()
+        request = self._record_request()
+        time.sleep(data_storage["put_delay"])
+        body = b""
+        if "uploads=" in self.path:
+            body = b"<InitiateMultipartUploadResult><UploadId>test-upload</UploadId></InitiateMultipartUploadResult>"
+        request["finished"] = time.monotonic()
         self.send_response(200)
-        self.send_header("Content-Length", "0")
+        self.send_header("Content-Length", str(len(body)))
         self.end_headers()
+        if body:
+            self.wfile.write(body)
+        request["status"] = 200
 
     def do_GET(self):
         if self.path == "/ping":

--- a/tests/integration/src/utils/fluent_bit_manager.py
+++ b/tests/integration/src/utils/fluent_bit_manager.py
@@ -267,6 +267,8 @@ class FluentBitManager:
                 timeout = self.shutdown_timeout
                 if timeout is None:
                     timeout = LEAKS_EXIT_TIMEOUT if leaks_enabled() else 10
+                elif leaks_enabled():
+                    timeout = max(timeout, LEAKS_EXIT_TIMEOUT)
                 return_code = self.process.wait(timeout=timeout)
             except subprocess.TimeoutExpired:
                 self._force_stop()

--- a/tests/integration/src/utils/fluent_bit_manager.py
+++ b/tests/integration/src/utils/fluent_bit_manager.py
@@ -430,8 +430,8 @@ class FluentBitManager:
                     if uptime > 1:
                         logger.info("Fluent Bit is running, health check OK")
                         return True
-            except requests.ConnectionError:
-                # it's ok to fail, we are testing
+            except (requests.ConnectionError, requests.Timeout):
+                # Startup can temporarily delay responses, especially under Valgrind.
                 pass
 
             time.sleep(1)

--- a/tests/integration/src/utils/fluent_bit_manager.py
+++ b/tests/integration/src/utils/fluent_bit_manager.py
@@ -156,9 +156,10 @@ def fluent_bit_input_supports_config_property(plugin_name, property_name, binary
 
 
 class FluentBitManager:
-    def __init__(self, config_path=None, binary_path=None):
+    def __init__(self, config_path=None, binary_path=None, *, shutdown_timeout=None):
         logger.info(f"config path {config_path}")
         self.config_path = config_path
+        self.shutdown_timeout = shutdown_timeout
         self.binary_path = binary_path or os.environ.get(ENV_FLB_BINARY_PATH) or _default_binary_path()
         self.binary_absolute_path = _resolve_binary_path(self.binary_path)
         self.process = None
@@ -263,7 +264,9 @@ class FluentBitManager:
 
         if supervisor_running:
             try:
-                timeout = LEAKS_EXIT_TIMEOUT if leaks_enabled() else 10
+                timeout = self.shutdown_timeout
+                if timeout is None:
+                    timeout = LEAKS_EXIT_TIMEOUT if leaks_enabled() else 10
                 return_code = self.process.wait(timeout=timeout)
             except subprocess.TimeoutExpired:
                 self._force_stop()

--- a/tests/integration/src/utils/test_service.py
+++ b/tests/integration/src/utils/test_service.py
@@ -33,6 +33,7 @@ class FluentBitTestService:
         extra_env=None,
         pre_start=None,
         post_stop=None,
+        shutdown_timeout=None,
     ):
         self.config_path = config_path
         self.data_storage = data_storage
@@ -40,6 +41,7 @@ class FluentBitTestService:
         self.extra_env = extra_env or {}
         self.pre_start = pre_start
         self.post_stop = post_stop
+        self.shutdown_timeout = shutdown_timeout
         self.flb = None
         self._previous_env = {}
         self._allocated_ports = set()
@@ -76,7 +78,7 @@ class FluentBitTestService:
 
     def start(self):
         self._reset_storage()
-        self.flb = FluentBitManager(self.config_path)
+        self.flb = FluentBitManager(self.config_path, shutdown_timeout=self.shutdown_timeout)
         self.flb_listener_port = self._allocate_port()
         self.test_suite_http_port = self._allocate_port()
         self._set_env("FLUENT_BIT_TEST_LISTENER_PORT", str(self.flb_listener_port))

--- a/tests/integration/test_macos_leaks_manager.py
+++ b/tests/integration/test_macos_leaks_manager.py
@@ -1,4 +1,5 @@
 import signal
+import subprocess
 
 import pytest
 
@@ -130,6 +131,44 @@ def test_leaks_strict_fails_when_leaks_reports_leak(monkeypatch, tmp_path):
 
     with pytest.raises(AssertionError, match="memory leaks were detected"):
         manager.stop()
+
+
+@pytest.mark.parametrize("configured,expected", [
+    (None, manager_module.LEAKS_EXIT_TIMEOUT),
+    (30, manager_module.LEAKS_EXIT_TIMEOUT),
+    (manager_module.LEAKS_EXIT_TIMEOUT, manager_module.LEAKS_EXIT_TIMEOUT),
+    (240, 240),
+])
+def test_leaks_shutdown_timeout_preserves_supervisor_allowance(monkeypatch, configured, expected):
+    process = FakeProcess()
+    delivered_signals = []
+    wait_timeouts = []
+    monkeypatch.delenv("VALGRIND", raising=False)
+    monkeypatch.setenv("LEAKS", "1")
+    monkeypatch.setenv("LEAKS_STRICT", "1")
+    monkeypatch.setattr(
+        manager_module.os, "kill",
+        lambda pid, signal_number: delivered_signals.append((pid, signal_number)),
+    )
+
+    def slow_supervisor_wait(timeout=None):
+        wait_timeouts.append(timeout)
+        if timeout < 90:
+            raise subprocess.TimeoutExpired("leaks", timeout)
+        process.returncode = 0
+        return 0
+
+    process.wait = slow_supervisor_wait
+    manager = FluentBitManager("/tmp/fluent-bit.yaml", shutdown_timeout=configured)
+    manager.process = process
+    manager.target_pid = 4321
+
+    manager.stop()
+
+    assert wait_timeouts == [expected]
+    assert delivered_signals == [(4321, signal.SIGTERM)]
+    assert process.killed is False
+    assert process.returncode == 0
 
 
 def test_leaks_supervisor_failure_still_terminates_target(monkeypatch):

--- a/tests/integration/tests/test_fluent_bit_manager.py
+++ b/tests/integration/tests/test_fluent_bit_manager.py
@@ -162,6 +162,20 @@ def test_send_sighup_forwards_signal_to_process():
     manager.process.send_signal.assert_called_once_with(signal.SIGHUP)
 
 
+def test_stop_uses_configured_shutdown_timeout(monkeypatch):
+    monkeypatch.delenv("VALGRIND", raising=False)
+    monkeypatch.delenv("LEAKS", raising=False)
+    manager = FluentBitManager("/tmp/fluent-bit.yaml", shutdown_timeout=30)
+    process = Mock()
+    process.poll.return_value = None
+    manager.process = process
+
+    manager.stop()
+
+    process.send_signal.assert_called_once_with(signal.SIGTERM)
+    process.wait.assert_called_once_with(timeout=30)
+
+
 def test_trigger_http_reload_posts_to_reload_endpoint(monkeypatch):
     response = Mock()
     response.json.return_value = {"reload": "done"}

--- a/tests/integration/tests/test_fluent_bit_manager.py
+++ b/tests/integration/tests/test_fluent_bit_manager.py
@@ -234,6 +234,34 @@ def test_start_uses_unique_valgrind_log_path(monkeypatch, tmp_path):
     ]]
 
 
+@pytest.mark.parametrize("error", [requests.ConnectionError, requests.ReadTimeout])
+def test_startup_health_check_retries_transient_errors(monkeypatch, error):
+    manager = FluentBitManager("/tmp/fluent-bit.yaml")
+    manager.http_monitoring_port = "2020"
+    response = Mock(status_code=200)
+    response.json.return_value = {"uptime_sec": 2}
+    get = Mock(side_effect=[error("not ready"), response])
+    monkeypatch.setattr(manager_module.requests, "get", get)
+    monkeypatch.setattr(manager_module.time, "sleep", lambda _: None)
+
+    assert manager.wait_for_fluent_bit(timeout=5) is True
+    assert get.call_count == 2
+
+
+def test_startup_health_check_timeouts_respect_deadline(monkeypatch):
+    manager = FluentBitManager("/tmp/fluent-bit.yaml")
+    manager.http_monitoring_port = "2020"
+    timestamps = iter([0.0, 0.1, 0.2, 0.3])
+    monkeypatch.setattr(manager_module.time, "time", lambda: next(timestamps))
+    monkeypatch.setattr(manager_module.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        manager_module.requests, "get", Mock(side_effect=requests.ReadTimeout("not ready"))
+    )
+
+    with pytest.raises(manager_module.FluentBitStartupError, match="did not start within"):
+        manager.wait_for_fluent_bit(timeout=0.25)
+
+
 def test_wait_for_hot_reload_count_returns_when_expected_count_is_reached(monkeypatch):
     manager = FluentBitManager("/tmp/fluent-bit.yaml")
     manager.http_monitoring_port = "2020"

--- a/tests/integration/tests/test_fluent_bit_manager.py
+++ b/tests/integration/tests/test_fluent_bit_manager.py
@@ -162,10 +162,11 @@ def test_send_sighup_forwards_signal_to_process():
     manager.process.send_signal.assert_called_once_with(signal.SIGHUP)
 
 
-def test_stop_uses_configured_shutdown_timeout(monkeypatch):
+@pytest.mark.parametrize("configured,expected", [(None, 10), (30, 30), (240, 240)])
+def test_stop_uses_configured_shutdown_timeout(monkeypatch, configured, expected):
     monkeypatch.delenv("VALGRIND", raising=False)
     monkeypatch.delenv("LEAKS", raising=False)
-    manager = FluentBitManager("/tmp/fluent-bit.yaml", shutdown_timeout=30)
+    manager = FluentBitManager("/tmp/fluent-bit.yaml", shutdown_timeout=configured)
     process = Mock()
     process.poll.return_value = None
     manager.process = process
@@ -173,7 +174,7 @@ def test_stop_uses_configured_shutdown_timeout(monkeypatch):
     manager.stop()
 
     process.send_signal.assert_called_once_with(signal.SIGTERM)
-    process.wait.assert_called_once_with(timeout=30)
+    process.wait.assert_called_once_with(timeout=expected)
 
 
 def test_trigger_http_reload_posts_to_reload_endpoint(monkeypatch):

--- a/tests/integration/tests/test_s3_server.py
+++ b/tests/integration/tests/test_s3_server.py
@@ -1,0 +1,63 @@
+#  Fluent Bit
+#  ==========
+#  Copyright (C) 2015-2026 The Fluent Bit Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import Mock
+
+from src.server import s3_server
+
+
+def test_tagged_upload_barrier_releases_distinct_tags():
+    barrier = s3_server.TaggedUploadBarrier(["first", "second"], timeout=1)
+    with ThreadPoolExecutor(max_workers=2) as workers:
+        first = workers.submit(barrier.wait, "first")
+        second = workers.submit(barrier.wait, "second")
+        assert first.result() is True
+        assert second.result() is True
+    assert barrier.wait("first") is None
+
+
+def test_tagged_upload_barrier_detects_serialized_requests():
+    barrier = s3_server.TaggedUploadBarrier(["first", "second"], timeout=0.01)
+    assert barrier.wait("first") is False
+    assert barrier.wait("second") is False
+
+
+def test_request_start_is_captured_before_reading_body(monkeypatch):
+    calls = []
+    handler = s3_server._S3RequestHandler.__new__(s3_server._S3RequestHandler)
+    handler.headers = {"Content-Length": "4"}
+    handler.command = "PUT"
+    handler.path = "/bucket/tag/key"
+    handler.rfile = Mock()
+
+    def started():
+        calls.append("start")
+        return 1.0
+
+    def read(size):
+        calls.append("read")
+        return b"body"
+
+    handler.rfile.read.side_effect = read
+    monkeypatch.setattr(s3_server.time, "monotonic", started)
+    monkeypatch.setitem(s3_server.data_storage, "requests", [])
+
+    request = handler._record_request()
+
+    assert calls == ["start", "read"]
+    assert request["started"] == 1.0
+    assert request["body"] == b"body"

--- a/tests/runtime/out_s3.c
+++ b/tests/runtime/out_s3.c
@@ -183,6 +183,47 @@ static void wait_for_s3_call_count(const char *api, int expected)
                                         S3_TEST_WAIT_TIMEOUT_MS);
 }
 
+static void wait_for_s3_retry_time(struct flb_s3 *ctx, time_t expected)
+{
+    uint64_t elapsed_ms;
+    struct flb_time start_time;
+    struct flb_time end_time;
+    struct flb_time diff_time;
+
+    elapsed_ms = 0;
+    flb_time_get(&start_time);
+
+    while (ctx->retry_time != expected && elapsed_ms < S3_TEST_WAIT_TIMEOUT_MS) {
+        flb_time_msleep(S3_TEST_WAIT_STEP_MS);
+        flb_time_get(&end_time);
+        flb_time_diff(&end_time, &start_time, &diff_time);
+        elapsed_ms = flb_time_to_nanosec(&diff_time) / 1000000;
+    }
+}
+
+static struct s3_file *wait_for_s3_file(struct flb_s3 *ctx, const char *tag, int tag_len)
+{
+    uint64_t elapsed_ms;
+    struct flb_time start_time;
+    struct flb_time end_time;
+    struct flb_time diff_time;
+    struct s3_file *s3_file;
+
+    elapsed_ms = 0;
+    flb_time_get(&start_time);
+    s3_file = s3_store_file_get(ctx, tag, tag_len);
+
+    while (s3_file == NULL && elapsed_ms < S3_TEST_WAIT_TIMEOUT_MS) {
+        flb_time_msleep(S3_TEST_WAIT_STEP_MS);
+        flb_time_get(&end_time);
+        flb_time_diff(&end_time, &start_time, &diff_time);
+        elapsed_ms = flb_time_to_nanosec(&diff_time) / 1000000;
+        s3_file = s3_store_file_get(ctx, tag, tag_len);
+    }
+
+    return s3_file;
+}
+
 static void wait_for_file_count(const char *path, int expected)
 {
     uint64_t elapsed_ms;
@@ -219,6 +260,74 @@ static void wait_for_file_count_at_most(const char *path, int expected)
         flb_time_diff(&end_time, &start_time, &diff_time);
         elapsed_ms = flb_time_to_nanosec(&diff_time) / 1000000;
     }
+}
+
+static int wait_for_s3_file_create_time(struct flb_s3 *ctx, const char *tag,
+                                        int tag_len, time_t create_time)
+{
+    uint64_t elapsed_ms;
+    struct s3_file *s3_file;
+    struct flb_time start_time;
+    struct flb_time end_time;
+    struct flb_time diff_time;
+
+    elapsed_ms = 0;
+    flb_time_get(&start_time);
+
+    /* The backing file can be visible before its in-memory state is registered. */
+    while (elapsed_ms < S3_TEST_WAIT_TIMEOUT_MS) {
+        pthread_mutex_lock(&ctx->files_mutex);
+        s3_file = s3_store_file_get(ctx, tag, tag_len);
+        if (s3_file != NULL) {
+            s3_file->create_time = create_time;
+            pthread_mutex_unlock(&ctx->files_mutex);
+            return 0;
+        }
+        pthread_mutex_unlock(&ctx->files_mutex);
+
+        flb_time_msleep(S3_TEST_WAIT_STEP_MS);
+        flb_time_get(&end_time);
+        flb_time_diff(&end_time, &start_time, &diff_time);
+        elapsed_ms = flb_time_to_nanosec(&diff_time) / 1000000;
+    }
+
+    return -1;
+}
+
+static int prepare_s3_ordered_files(struct flb_s3 *ctx)
+{
+    uint64_t elapsed_ms;
+    time_t now;
+    struct s3_file *oldest_file;
+    struct s3_file *later_file;
+    struct flb_time start_time;
+    struct flb_time end_time;
+    struct flb_time diff_time;
+
+    elapsed_ms = 0;
+    flb_time_get(&start_time);
+
+    while (elapsed_ms < S3_TEST_WAIT_TIMEOUT_MS) {
+        pthread_mutex_lock(&ctx->files_mutex);
+        oldest_file = s3_store_file_get(ctx, "oldest", 6);
+        later_file = s3_store_file_get(ctx, "later", 5);
+        if (oldest_file != NULL && later_file != NULL) {
+            /* Publish both deadlines together so the timer sees the intended order. */
+            now = time(NULL);
+            oldest_file->create_time = now - 30;
+            later_file->create_time = now - 20;
+            pthread_mutex_unlock(&ctx->files_mutex);
+            return 0;
+        }
+        pthread_mutex_unlock(&ctx->files_mutex);
+
+        flb_time_msleep(S3_TEST_WAIT_STEP_MS);
+        flb_time_get(&end_time);
+        flb_time_diff(&end_time, &start_time, &diff_time);
+        elapsed_ms = flb_time_to_nanosec(&diff_time) / 1000000;
+    }
+
+    return -1;
 }
 
 static int ensure_test_directory(const char *path)
@@ -656,7 +765,6 @@ void flb_test_s3_ordered_retry_uses_backoff_deadline(void)
     flb_ctx_t *ctx;
     char *store_dir;
     struct flb_s3 *s3_ctx;
-    struct s3_file *s3_file;
 
     store_dir = create_test_store_directory("/flb-s3-test-retry-deadline-XXXXXX");
     TEST_CHECK(store_dir != NULL);
@@ -694,17 +802,25 @@ void flb_test_s3_ordered_retry_uses_backoff_deadline(void)
     TEST_CHECK(ret >= 0);
     s3_ctx = get_s3_context(ctx);
     TEST_CHECK(s3_ctx != NULL);
-    wait_for_file_count(s3_ctx->stream_active->path, 1);
-
-    s3_file = s3_store_file_get(s3_ctx, "retry-deadline", 14);
-    TEST_CHECK(s3_file != NULL);
-    s3_file->create_time = time(NULL) - 61;
+    ret = wait_for_s3_file_create_time(s3_ctx, "retry-deadline", 14,
+                                       time(NULL) - 61);
+    TEST_CHECK_(ret == 0, "Expected retry-deadline chunk to be created");
+    if (ret != 0) {
+        flb_stop(ctx);
+        flb_destroy(ctx);
+        unsetenv("FLB_S3_PLUGIN_UNDER_TEST");
+        unsetenv("TEST_UPLOAD_PART_ERROR");
+        unsetenv("TEST_CreateMultipartUpload_CALL_COUNT");
+        unsetenv("TEST_UploadPart_CALL_COUNT");
+        flb_free(store_dir);
+        return;
+    }
 
     ret = flb_lib_push(ctx, in_ffd, (char *) JSON_TD,
                        (int) sizeof(JSON_TD) - 1);
     TEST_CHECK(ret >= 0);
     wait_for_s3_call_count("UploadPart", 1);
-    flb_time_msleep(100);
+    wait_for_s3_retry_time(s3_ctx, 2);
     TEST_CHECK_(s3_ctx->retry_time == 2,
                 "Expected first retry to add a 2 second timeout offset, got %lld",
                 (long long) s3_ctx->retry_time);
@@ -715,6 +831,8 @@ void flb_test_s3_ordered_retry_uses_backoff_deadline(void)
                 get_s3_call_count("UploadPart"));
     TEST_CHECK_(count_files_recursive(s3_ctx->stream_active->path) == 0,
                 "Expected retry-exhausted chunk to be deleted before periodic timer");
+    /* Unlinking the chunk precedes the worker's retry state reset. */
+    wait_for_s3_retry_time(s3_ctx, 0);
     TEST_CHECK_(s3_ctx->retry_time == 0,
                 "Expected terminal cleanup to reset the timeout offset");
 
@@ -738,8 +856,6 @@ void flb_test_s3_ordered_timer_isolates_tag_backoff(void)
     flb_ctx_t *ctx;
     char *store_dir;
     struct flb_s3 *s3_ctx;
-    struct s3_file *oldest_file;
-    struct s3_file *later_file;
 
     store_dir = create_test_store_directory("/flb-s3-test-timer-order-XXXXXX");
     TEST_CHECK(store_dir != NULL);
@@ -783,15 +899,12 @@ void flb_test_s3_ordered_timer_isolates_tag_backoff(void)
 
     s3_ctx = get_s3_context(ctx);
     TEST_CHECK(s3_ctx != NULL);
-    wait_for_file_count(s3_ctx->stream_active->path, 2);
-    oldest_file = s3_store_file_get(s3_ctx, "oldest", 6);
-    later_file = s3_store_file_get(s3_ctx, "later", 5);
-    TEST_CHECK(oldest_file != NULL);
-    TEST_CHECK(later_file != NULL);
-    oldest_file->create_time = time(NULL) - 30;
-    later_file->create_time = time(NULL) - 20;
-
     setenv("TEST_PUT_OBJECT_ERROR", ERROR_ACCESS_DENIED, 1);
+    ret = prepare_s3_ordered_files(s3_ctx);
+    TEST_CHECK_(ret == 0, "Expected both ordered chunks to be created");
+    if (ret != 0) {
+        goto cleanup;
+    }
     wait_for_s3_call_count("PutObject", 1);
     flb_time_msleep(500);
 
@@ -816,6 +929,7 @@ void flb_test_s3_ordered_timer_isolates_tag_backoff(void)
                 "Expected failed tag to retry at its deadline, got %s",
                 uri ? uri : "(null)");
 
+cleanup:
     flb_stop(ctx);
     flb_destroy(ctx);
 
@@ -887,6 +1001,7 @@ void flb_test_s3_ordered_construct_error_exhausts_chunk(void)
 
     TEST_CHECK_(count_files_recursive(s3_ctx->stream_active->path) == 0,
                 "Expected unreadable queue head to reach terminal cleanup");
+    wait_for_s3_retry_time(s3_ctx, 0);
     TEST_CHECK_(mk_list_is_empty(&s3_ctx->upload_queue) == 0,
                 "Expected queue to be empty after construction retry exhaustion");
     TEST_CHECK_(s3_ctx->retry_time == 0,
@@ -950,9 +1065,12 @@ void flb_test_s3_ordered_backoff_does_not_starve_completion(void)
     ret = flb_lib_push(ctx, input_fds[0], (char *) JSON_TD,
                        (int) sizeof(JSON_TD) - 1);
     TEST_CHECK(ret >= 0);
-    wait_for_file_count(s3_ctx->stream_active->path, 1);
-    s3_file = s3_store_file_get(s3_ctx, "completing", 10);
+    /* Wait for the requested tag's initialized chunk, not an on-disk file. */
+    s3_file = wait_for_s3_file(s3_ctx, "completing", 10);
     TEST_CHECK(s3_file != NULL);
+    if (s3_file == NULL) {
+        goto cleanup;
+    }
     s3_file->create_time = time(NULL) - 61;
     ret = flb_lib_push(ctx, input_fds[0], (char *) JSON_TD,
                        (int) sizeof(JSON_TD) - 1);
@@ -962,9 +1080,11 @@ void flb_test_s3_ordered_backoff_does_not_starve_completion(void)
     ret = flb_lib_push(ctx, input_fds[1], (char *) JSON_TD,
                        (int) sizeof(JSON_TD) - 1);
     TEST_CHECK(ret >= 0);
-    wait_for_file_count(s3_ctx->stream_active->path, 1);
-    s3_file = s3_store_file_get(s3_ctx, "backoff", 7);
+    s3_file = wait_for_s3_file(s3_ctx, "backoff", 7);
     TEST_CHECK(s3_file != NULL);
+    if (s3_file == NULL) {
+        goto cleanup;
+    }
     s3_file->create_time = time(NULL) - 61;
     setenv("TEST_CREATE_MULTIPART_UPLOAD_ERROR", ERROR_ACCESS_DENIED, 1);
     ret = flb_lib_push(ctx, input_fds[1], (char *) JSON_TD,
@@ -976,6 +1096,7 @@ void flb_test_s3_ordered_backoff_does_not_starve_completion(void)
     TEST_CHECK_(get_s3_call_count("CompleteMultipartUpload") >= 2,
                 "Expected pending completion to run while queue head was backing off");
 
+cleanup:
     unsetenv("TEST_CREATE_MULTIPART_UPLOAD_ERROR");
     unsetenv("TEST_COMPLETE_MULTIPART_UPLOAD_ERROR");
     flb_stop(ctx);
@@ -1638,8 +1759,6 @@ void flb_test_s3_ordered_index_keeps_global_queue_order(void)
     flb_ctx_t *ctx;
     char *store_dir;
     struct flb_s3 *s3_ctx;
-    struct s3_file *oldest_file;
-    struct s3_file *later_file;
 
     store_dir = create_test_store_directory("/flb-s3-test-index-order-XXXXXX");
     TEST_CHECK(store_dir != NULL);
@@ -1683,15 +1802,12 @@ void flb_test_s3_ordered_index_keeps_global_queue_order(void)
 
     s3_ctx = get_s3_context(ctx);
     TEST_CHECK(s3_ctx != NULL);
-    wait_for_file_count(s3_ctx->stream_active->path, 2);
-    oldest_file = s3_store_file_get(s3_ctx, "oldest", 6);
-    later_file = s3_store_file_get(s3_ctx, "later", 5);
-    TEST_CHECK(oldest_file != NULL);
-    TEST_CHECK(later_file != NULL);
-    oldest_file->create_time = time(NULL) - 30;
-    later_file->create_time = time(NULL) - 20;
-
     setenv("TEST_PUT_OBJECT_ERROR", ERROR_ACCESS_DENIED, 1);
+    ret = prepare_s3_ordered_files(s3_ctx);
+    TEST_CHECK_(ret == 0, "Expected both ordered chunks to be created");
+    if (ret != 0) {
+        goto cleanup;
+    }
     wait_for_s3_call_count("PutObject", 1);
     flb_time_msleep(500);
 
@@ -1714,6 +1830,7 @@ void flb_test_s3_ordered_index_keeps_global_queue_order(void)
                 "Expected later indexed chunk after retry, got %s",
                 uri ? uri : "(null)");
 
+cleanup:
     flb_stop(ctx);
     flb_destroy(ctx);
 

--- a/tests/runtime/out_s3.c
+++ b/tests/runtime/out_s3.c
@@ -2180,8 +2180,151 @@ void flb_test_s3_startup_buffer_size_accounting(void)
     flb_free(store_dir);
 }
 
+/* Detect overlapping cache reads/refreshes while requests remain concurrent. */
+struct s3_credentials_test {
+    pthread_mutex_t mutex;
+    int requests_entered;
+    int active;
+    int max_active;
+    int gets;
+    int refreshes;
+    int request_wait_failed;
+};
+
+static struct s3_credentials_test credentials_test;
+
+static void s3_test_provider_access(int refresh)
+{
+    pthread_mutex_lock(&credentials_test.mutex);
+    credentials_test.active++;
+    if (credentials_test.active > credentials_test.max_active) {
+        credentials_test.max_active = credentials_test.active;
+    }
+    if (refresh) {
+        credentials_test.refreshes++;
+    }
+    else {
+        credentials_test.gets++;
+    }
+    pthread_mutex_unlock(&credentials_test.mutex);
+
+    flb_time_msleep(5);
+
+    pthread_mutex_lock(&credentials_test.mutex);
+    credentials_test.active--;
+    pthread_mutex_unlock(&credentials_test.mutex);
+}
+
+static struct flb_aws_credentials *s3_test_get_credentials(struct flb_aws_provider *provider)
+{
+    s3_test_provider_access(FLB_FALSE);
+    return flb_calloc(1, sizeof(struct flb_aws_credentials));
+}
+
+static int s3_test_refresh_credentials(struct flb_aws_provider *provider)
+{
+    s3_test_provider_access(FLB_TRUE);
+    return 0;
+}
+
+static struct flb_http_client *s3_test_concurrent_request(struct flb_aws_client *client,
+                                                         int method, const char *uri,
+                                                         const char *body, size_t body_size,
+                                                         struct flb_aws_header *headers,
+                                                         size_t headers_count)
+{
+    struct flb_aws_credentials *credentials;
+    int i;
+    int ready = FLB_FALSE;
+
+    pthread_mutex_lock(&credentials_test.mutex);
+    credentials_test.requests_entered++;
+    pthread_mutex_unlock(&credentials_test.mutex);
+
+    /* A bounded rendezvous also catches accidentally serializing entire requests. */
+    for (i = 0; i < 500; i++) {
+        pthread_mutex_lock(&credentials_test.mutex);
+        ready = credentials_test.requests_entered == 2;
+        pthread_mutex_unlock(&credentials_test.mutex);
+        if (ready) {
+            break;
+        }
+        flb_time_msleep(10);
+    }
+    if (!ready) {
+        pthread_mutex_lock(&credentials_test.mutex);
+        credentials_test.request_wait_failed = FLB_TRUE;
+        pthread_mutex_unlock(&credentials_test.mutex);
+    }
+
+    for (i = 0; i < 20; i++) {
+        credentials = client->provider->provider_vtable->get_credentials(client->provider);
+        flb_aws_credentials_destroy(credentials);
+        client->provider->provider_vtable->refresh(client->provider);
+    }
+    return NULL;
+}
+
+static void *s3_test_request_worker(void *data)
+{
+    struct flb_s3 *ctx = data;
+
+    pthread_mutex_lock(&ctx->files_mutex);
+    s3_request(ctx, FLB_HTTP_PUT, "/test", NULL, 0, NULL, 0);
+    pthread_mutex_unlock(&ctx->files_mutex);
+    return NULL;
+}
+
+static void flb_test_s3_credentials_serialized(void)
+{
+    struct flb_s3 ctx = {0};
+    struct flb_aws_provider provider = {0};
+    struct flb_aws_client client = {0};
+    struct flb_aws_provider_vtable provider_vtable = {
+        .get_credentials = s3_test_get_credentials,
+        .refresh = s3_test_refresh_credentials
+    };
+    struct flb_aws_client_vtable client_vtable = {
+        .request = s3_test_concurrent_request
+    };
+    pthread_t workers[2];
+    int created = 0;
+    int ret;
+    int i;
+
+    memset(&credentials_test, 0, sizeof(credentials_test));
+    pthread_mutex_init(&credentials_test.mutex, NULL);
+    pthread_mutex_init(&ctx.files_mutex, NULL);
+    provider.provider_vtable = &provider_vtable;
+    client.client_vtable = &client_vtable;
+    client.provider = &provider;
+    ctx.provider = &provider;
+    ctx.s3_client = &client;
+
+    for (i = 0; i < 2; i++) {
+        ret = pthread_create(&workers[i], NULL, s3_test_request_worker, &ctx);
+        TEST_CHECK(ret == 0);
+        if (ret != 0) {
+            break;
+        }
+        created++;
+    }
+    for (i = 0; i < created; i++) {
+        pthread_join(workers[i], NULL);
+    }
+
+    TEST_CHECK(credentials_test.request_wait_failed == FLB_FALSE);
+    TEST_CHECK(credentials_test.requests_entered == 2);
+    TEST_CHECK(credentials_test.max_active == 1);
+    TEST_CHECK(credentials_test.gets == 40);
+    TEST_CHECK(credentials_test.refreshes == 40);
+    pthread_mutex_destroy(&ctx.files_mutex);
+    pthread_mutex_destroy(&credentials_test.mutex);
+}
+
 /* Test list */
 TEST_LIST = {
+    {"credentials_serialized", flb_test_s3_credentials_serialized },
     {"multipart_success", flb_test_s3_multipart_success },
     {"putobject_success", flb_test_s3_putobject_success },
     {"putobject_error", flb_test_s3_putobject_error },


### PR DESCRIPTION
<!-- Provide summary of changes -->

The mitigation replaces broad upload serialization with **per-tag ownership claims**, allowing different tags to upload concurrently while protecting each tag’s chunks and multipart state.

Implementation details:

- The store mutex protects shared lists, queues, lookups, and state changes.
- A tag claim remains active while compression and synchronous network requests run outside the mutex.
- Other workers encountering a claimed tag buffer incoming data; upload and completion scans skip that tag.
- Queue entries track in-flight work. Scans restart after unlocked operations rather than retaining iterators that another worker could invalidate.
- Multipart completion holds the same tag claim through the request and cleanup.
- `$INDEX` configurations retain global serialization to protect the shared sequence.
- AWS requests use a local client snapshot, reconciling mutable client fields after reacquiring the mutex.

The mitigation plan is to retain the landed serialization fix as the safe baseline and validate the narrower claims before relying on their concurrency benefit:

1. Correct the concurrency test sizes. Currently, the PutObject cases fail initialization, and the multipart case falls back to PutObject.
2. Verify that different tags overlap, same-tag operations remain exclusive, and `$INDEX` uploads stay serialized.
3. Run those corrected cases normally and under strict Valgrind, including multipart completion, retry exhaustion, and restart recovery.
4. Keep the broader serialization available as a fallback if ownership failures recur.

Current evidence supports the approach: the build, S3 runtime suite, and six retry/recovery integration cases passed; those six also passed strict Valgrind.

Closes https://github.com/fluent/fluent-bit/issues/12377.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved S3 reliability during concurrent log and blob uploads.
  - Improved multipart upload completion, recovery, and ordering across restarts.
  - Improved handling of request failures, credential refreshes, and upload retries.
  - Improved backlog draining and shutdown handling for pending uploads.

- **Enhancements**
  - Added safer concurrent AWS credential access while S3 requests continue processing.
  - Improved coordination of blob uploads to prevent overlapping operations and inconsistent upload state.
  - Improved shutdown timeout handling and startup recovery for integration services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->