### PR TITLE
github: workflows: Mitigate order dependent issue for uploading task for Windows

### DIFF
--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -327,6 +327,17 @@ jobs:
               echo "::error::Missing Windows release artifact: $package or $package.sha256. Complete the Windows staging build/upload before releasing."
               exit 1
             fi
+            if ! awk -v package="$package" '
+              {
+                valid = (length($1) == 64 && $1 ~ /^[[:xdigit:]]+$/ &&
+                         (substr($0, 65, 2) == "  " || substr($0, 65, 2) == " *") &&
+                         substr($0, 67) == package)
+              }
+              END { exit !(NR == 1 && valid) }
+            ' "$package.sha256"; then
+              echo "::error::Expected exactly one SHA-256 record for $package in $package.sha256"
+              exit 1
+            fi
             sha256sum --check --strict "$package.sha256"
           done
         done
@@ -1042,11 +1053,23 @@ jobs:
           write_hash()
           {
             local output_name="$1"
-            local filename="fluent-bit-${RELEASE_VERSION}-$2.sha256"
+            local package="fluent-bit-${RELEASE_VERSION}-$2"
+            local filename="$package.sha256"
             local hash
-            hash=$(awk '{print $1}' "$filename")
-            if [[ ! "$hash" =~ ^[[:xdigit:]]{64}$ ]]; then
-              echo "::error::Invalid SHA-256 checksum in $filename"
+            if ! hash=$(awk -v package="$package" '
+              {
+                valid = (length($1) == 64 && $1 ~ /^[[:xdigit:]]+$/ &&
+                         (substr($0, 65, 2) == "  " || substr($0, 65, 2) == " *") &&
+                         substr($0, 67) == package)
+              }
+              END {
+                if (NR != 1 || !valid) {
+                  exit 1
+                }
+                print $1
+              }
+            ' "$filename"); then
+              echo "::error::Expected exactly one SHA-256 record for $package in $filename"
               exit 1
             fi
             echo "$output_name=$hash" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -289,7 +289,7 @@ jobs:
     needs:
       - staging-release-version-check
     permissions:
-      contents: none
+      contents: read
     strategy:
       matrix:
         distro:
@@ -297,6 +297,12 @@ jobs:
           - windows
       fail-fast: false
     steps:
+    - name: Checkout repository
+      if: matrix.distro == 'windows'
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
     - name: Sync packages from buckets on S3
       # Repository generation moves existing packages to the bucket root, but
       # Windows/macOS uploads that finish later remain in the versioned prefix.
@@ -315,32 +321,7 @@ jobs:
     - name: Validate Windows release packages
       if: matrix.distro == 'windows'
       run: |
-        cd packaging/releases/windows
-        architectures=(win32 win64)
-        if compgen -G "fluent-bit-${RELEASE_VERSION}-winarm64.*" > /dev/null; then
-          architectures+=(winarm64)
-        fi
-        for arch in "${architectures[@]}"; do
-          for extension in exe zip; do
-            package="fluent-bit-${RELEASE_VERSION}-${arch}.${extension}"
-            if [[ ! -s "$package" || ! -s "$package.sha256" ]]; then
-              echo "::error::Missing Windows release artifact: $package or $package.sha256. Complete the Windows staging build/upload before releasing."
-              exit 1
-            fi
-            if ! awk -v package="$package" '
-              {
-                valid = (length($1) == 64 && $1 ~ /^[[:xdigit:]]+$/ &&
-                         (substr($0, 65, 2) == "  " || substr($0, 65, 2) == " *") &&
-                         substr($0, 67) == package)
-              }
-              END { exit !(NR == 1 && valid) }
-            ' "$package.sha256"; then
-              echo "::error::Expected exactly one SHA-256 record for $package in $package.sha256"
-              exit 1
-            fi
-            sha256sum --check --strict "$package.sha256"
-          done
-        done
+        bash packaging/validate-windows-release-packages.sh "$RELEASE_VERSION" packaging/releases/windows
       env:
         RELEASE_VERSION: ${{ inputs.version }}
       shell: bash
@@ -1028,7 +1009,7 @@ jobs:
     needs:
       - staging-release-update-non-linux-s3
     permissions:
-      contents: none
+      contents: read
     outputs:
       windows-exe32-hash: ${{ steps.hashes.outputs.WIN_32_EXE_HASH }}
       windows-zip32-hash: ${{ steps.hashes.outputs.WIN_32_ZIP_HASH }}
@@ -1037,6 +1018,11 @@ jobs:
       windows-arm-exe64-hash: ${{ steps.hashes.outputs.WIN_64_ARM_EXE_HASH }}
       windows-arm-zip64-hash: ${{ steps.hashes.outputs.WIN_64_ARM_ZIP_HASH }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       - name: Sync release Windows directory to get checksums
         run:
           aws s3 sync "s3://${{ secrets.AWS_S3_BUCKET_RELEASE }}/windows" ./ --exclude "*" --include "fluent-bit-${RELEASE_VERSION}-*.sha256"
@@ -1050,39 +1036,7 @@ jobs:
       - name: Provide output for documentation PR
         id: hashes
         run: |
-          write_hash()
-          {
-            local output_name="$1"
-            local package="fluent-bit-${RELEASE_VERSION}-$2"
-            local filename="$package.sha256"
-            local hash
-            if ! hash=$(awk -v package="$package" '
-              {
-                valid = (length($1) == 64 && $1 ~ /^[[:xdigit:]]+$/ &&
-                         (substr($0, 65, 2) == "  " || substr($0, 65, 2) == " *") &&
-                         substr($0, 67) == package)
-              }
-              END {
-                if (NR != 1 || !valid) {
-                  exit 1
-                }
-                print $1
-              }
-            ' "$filename"); then
-              echo "::error::Expected exactly one SHA-256 record for $package in $filename"
-              exit 1
-            fi
-            echo "$output_name=$hash" >> "$GITHUB_OUTPUT"
-          }
-
-          write_hash WIN_32_EXE_HASH win32.exe
-          write_hash WIN_32_ZIP_HASH win32.zip
-          write_hash WIN_64_EXE_HASH win64.exe
-          write_hash WIN_64_ZIP_HASH win64.zip
-          if compgen -G "fluent-bit-${RELEASE_VERSION}-winarm64.*.sha256" > /dev/null; then
-            write_hash WIN_64_ARM_EXE_HASH winarm64.exe
-            write_hash WIN_64_ARM_ZIP_HASH winarm64.zip
-          fi
+          bash packaging/windows-release-hashes.sh "$RELEASE_VERSION" . >> "$GITHUB_OUTPUT"
         env:
           RELEASE_VERSION: ${{ inputs.version }}
         shell: bash

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -298,15 +298,40 @@ jobs:
       fail-fast: false
     steps:
     - name: Sync packages from buckets on S3
+      # Repository generation moves existing packages to the bucket root, but
+      # Windows/macOS uploads that finish later remain in the versioned prefix.
       run: |
         mkdir -p "packaging/releases/$DISTRO"
         aws s3 sync "s3://${{ secrets.AWS_S3_BUCKET_RELEASE }}/$DISTRO" "packaging/releases/$DISTRO" --no-progress
+        aws s3 sync "s3://${{ secrets.AWS_S3_BUCKET_STAGING }}/$DISTRO" "packaging/releases/$DISTRO" --no-progress
         aws s3 sync "s3://${{ secrets.AWS_S3_BUCKET_STAGING }}/${{ github.event.inputs.version }}/$DISTRO" "packaging/releases/$DISTRO" --no-progress
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: "us-east-1"
         DISTRO: ${{ matrix.distro }}
+      shell: bash
+
+    - name: Validate Windows release packages
+      if: matrix.distro == 'windows'
+      run: |
+        cd packaging/releases/windows
+        architectures=(win32 win64)
+        if compgen -G "fluent-bit-${RELEASE_VERSION}-winarm64.*" > /dev/null; then
+          architectures+=(winarm64)
+        fi
+        for arch in "${architectures[@]}"; do
+          for extension in exe zip; do
+            package="fluent-bit-${RELEASE_VERSION}-${arch}.${extension}"
+            if [[ ! -s "$package" || ! -s "$package.sha256" ]]; then
+              echo "::error::Missing Windows release artifact: $package or $package.sha256. Complete the Windows staging build/upload before releasing."
+              exit 1
+            fi
+            sha256sum --check --strict "$package.sha256"
+          done
+        done
+      env:
+        RELEASE_VERSION: ${{ inputs.version }}
       shell: bash
 
     - name: Sync to release bucket on S3
@@ -1003,36 +1028,40 @@ jobs:
     steps:
       - name: Sync release Windows directory to get checksums
         run:
-          aws s3 sync "s3://${{ secrets.AWS_S3_BUCKET_RELEASE }}/windows" ./ --exclude "*" --include "*.sha256"
+          aws s3 sync "s3://${{ secrets.AWS_S3_BUCKET_RELEASE }}/windows" ./ --exclude "*" --include "fluent-bit-${RELEASE_VERSION}-*.sha256"
         shell: bash
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: "us-east-1"
+          RELEASE_VERSION: ${{ inputs.version }}
 
       - name: Provide output for documentation PR
         id: hashes
-        # do not fail the build for this
-        continue-on-error: true
         run: |
-          ls -l
-          export WIN_32_EXE_HASH=$(cat "./fluent-bit-${{ inputs.version }}-win32.exe.sha256"|awk '{print $1}')
-          export WIN_32_ZIP_HASH=$(cat "./fluent-bit-${{ inputs.version }}-win32.zip.sha256"|awk '{print $1}')
-          export WIN_64_EXE_HASH=$(cat "./fluent-bit-${{ inputs.version }}-win64.exe.sha256"|awk '{print $1}')
-          export WIN_64_ZIP_HASH=$(cat "./fluent-bit-${{ inputs.version }}-win64.zip.sha256"|awk '{print $1}')
-          if [[ -f "./fluent-bit-${{ inputs.version }}-winarm64.exe.sha256" ]]; then
-            export WIN_64_ARM_EXE_HASH=$(cat "./fluent-bit-${{ inputs.version }}-winarm64.exe.sha256"|awk '{print $1}')
+          write_hash()
+          {
+            local output_name="$1"
+            local filename="fluent-bit-${RELEASE_VERSION}-$2.sha256"
+            local hash
+            hash=$(awk '{print $1}' "$filename")
+            if [[ ! "$hash" =~ ^[[:xdigit:]]{64}$ ]]; then
+              echo "::error::Invalid SHA-256 checksum in $filename"
+              exit 1
+            fi
+            echo "$output_name=$hash" >> "$GITHUB_OUTPUT"
+          }
+
+          write_hash WIN_32_EXE_HASH win32.exe
+          write_hash WIN_32_ZIP_HASH win32.zip
+          write_hash WIN_64_EXE_HASH win64.exe
+          write_hash WIN_64_ZIP_HASH win64.zip
+          if compgen -G "fluent-bit-${RELEASE_VERSION}-winarm64.*.sha256" > /dev/null; then
+            write_hash WIN_64_ARM_EXE_HASH winarm64.exe
+            write_hash WIN_64_ARM_ZIP_HASH winarm64.zip
           fi
-          if [[ -f "./fluent-bit-${{ inputs.version }}-winarm64.zip.sha256" ]]; then
-            export WIN_64_ARM_ZIP_HASH=$(cat "./fluent-bit-${{ inputs.version }}-winarm64.zip.sha256"|awk '{print $1}')
-          fi
-          set | grep WIN_
-          echo WIN_32_EXE_HASH="$WIN_32_EXE_HASH" >> $GITHUB_OUTPUT
-          echo WIN_32_ZIP_HASH="$WIN_32_ZIP_HASH" >> $GITHUB_OUTPUT
-          echo WIN_64_EXE_HASH="$WIN_64_EXE_HASH" >> $GITHUB_OUTPUT
-          echo WIN_64_ZIP_HASH="$WIN_64_ZIP_HASH" >> $GITHUB_OUTPUT
-          echo WIN_64_ARM_EXE_HASH="$WIN_64_ARM_EXE_HASH" >> $GITHUB_OUTPUT
-          echo WIN_64_ARM_ZIP_HASH="$WIN_64_ARM_ZIP_HASH" >> $GITHUB_OUTPUT
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
         shell: bash
 
   staging-release-create-docs-pr:

--- a/packaging/validate-windows-release-packages.sh
+++ b/packaging/validate-windows-release-packages.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+# Usage: validate-windows-release-packages.sh VERSION [PACKAGE_DIRECTORY]
+# Require nonempty Windows packages and exactly one matching checksum record
+# per package, then verify the contents. ARM64 is optional for older releases.
+
+RELEASE_VERSION=${1:?Usage: validate-windows-release-packages.sh VERSION [PACKAGE_DIRECTORY]}
+SOURCE_DIR=${2:-.}
+
+cd "$SOURCE_DIR"
+
+architectures=(win32 win64)
+if compgen -G "fluent-bit-${RELEASE_VERSION}-winarm64.*" > /dev/null; then
+    architectures+=(winarm64)
+fi
+for arch in "${architectures[@]}"; do
+    for extension in exe zip; do
+        package="fluent-bit-${RELEASE_VERSION}-${arch}.${extension}"
+        if [[ ! -s "$package" || ! -s "$package.sha256" ]]; then
+            echo "ERROR: Missing Windows release artifact: $package or $package.sha256." >&2
+            echo "Complete the Windows staging build/upload before releasing." >&2
+            exit 1
+        fi
+        if ! awk -v package="$package" '
+          {
+            valid = (length($1) == 64 && $1 ~ /^[[:xdigit:]]+$/ &&
+                     (substr($0, 65, 2) == "  " || substr($0, 65, 2) == " *") &&
+                     substr($0, 67) == package)
+          }
+          END { exit !(NR == 1 && valid) }
+        ' "$package.sha256"; then
+            echo "ERROR: Expected exactly one SHA-256 record for $package in $package.sha256" >&2
+            exit 1
+        fi
+        sha256sum --check --strict "$package.sha256"
+    done
+done

--- a/packaging/windows-release-hashes.sh
+++ b/packaging/windows-release-hashes.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+# Usage: windows-release-hashes.sh VERSION [CHECKSUM_DIRECTORY]
+# Validate Windows release manifests and print NAME=hash records to stdout.
+# Diagnostics go to stderr so stdout can be appended to GITHUB_OUTPUT or reused
+# outside GitHub Actions. ARM64 is optional for older releases.
+
+RELEASE_VERSION=${1:?Usage: windows-release-hashes.sh VERSION [CHECKSUM_DIRECTORY]}
+SOURCE_DIR=${2:-.}
+
+write_hash()
+{
+    local output_name="$1"
+    local package="fluent-bit-${RELEASE_VERSION}-$2"
+    local filename="$package.sha256"
+    local hash
+
+    if ! hash=$(awk -v package="$package" '
+      {
+        valid = (length($1) == 64 && $1 ~ /^[[:xdigit:]]+$/ &&
+                 (substr($0, 65, 2) == "  " || substr($0, 65, 2) == " *") &&
+                 substr($0, 67) == package)
+      }
+      END {
+        if (NR != 1 || !valid) {
+          exit 1
+        }
+        print $1
+      }
+    ' "$filename"); then
+        echo "ERROR: Expected exactly one SHA-256 record for $package in $filename" >&2
+        exit 1
+    fi
+    echo "$output_name=$hash"
+}
+
+cd "$SOURCE_DIR"
+
+write_hash WIN_32_EXE_HASH win32.exe
+write_hash WIN_32_ZIP_HASH win32.zip
+write_hash WIN_64_EXE_HASH win64.exe
+write_hash WIN_64_ZIP_HASH win64.zip
+if compgen -G "fluent-bit-${RELEASE_VERSION}-winarm64.*.sha256" > /dev/null; then
+    write_hash WIN_64_ARM_EXE_HASH winarm64.exe
+    write_hash WIN_64_ARM_ZIP_HASH winarm64.zip
+fi


### PR DESCRIPTION
**5.1.1 succeeded because the jobs finished in a different order.** The relevant workflow logic was unchanged between the two tags.

| Release | Execution order | Windows package location |
|---|---|---|
| 5.1.1 | Metadata finished at 04:09 UTC; Windows uploaded at 04:31 | `5.1.1/windows/` remained available |
| 5.1.2 | Windows uploaded first; metadata ran afterward | Packages moved to `windows/`; `5.1.2/windows/` was deleted |

The logs confirm the [[late 5.1.1 upload](https://github.com/fluent/fluent-bit/actions/runs/31863188018/job/94963538053)](https://github.com/fluent/fluent-bit/actions/runs/31863188018/job/94963538053) and the [[5.1.2 relocation/deletion](https://github.com/fluent/fluent-bit/actions/runs/33913165633/job/101228522908)](https://github.com/fluent/fluent-bit/actions/runs/33913165633/job/101228522908).

The release job only checked the versioned location. For 5.1.2, it found no packages, leaving empty checksums and causing the documentation update to fail.

**This is a timing-dependent CI bug requiring a release-workflow fix, not changes to the 5.1.2 binaries.** Reading both staging locations accommodates either job order.


Addresses https://github.com/fluent/fluent-bit/issues/12309#issuecomment-5559158024

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Windows release artifacts are now validated against exact SHA-256 checksum entries.
  - Invalid, duplicate, or unrelated checksum entries cause validation to fail.
  - Checksum synchronization remains limited to files for the specific release version.
  - Windows ARM64 checksums are included when matching ARM64 release manifests are available.
  - Release checks also confirm that expected executable and archive packages are present, non-empty, and match their checksums.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->