### PR TITLE
out_opentelemetry: preserve failed log batch results

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry_logs.c
+++ b/plugins/out_opentelemetry/opentelemetry_logs.c
@@ -1572,6 +1572,11 @@ start_resource:
             free_log_records(log_records, log_record_count);
             log_record_count = 0;
             scope_log->n_log_records = 0;
+
+            /* Do not let a later batch overwrite this failure. */
+            if (ret != FLB_OK) {
+                break;
+            }
         }
     }
 

--- a/tests/integration/scenarios/out_opentelemetry/config/out_otel_http_logs_batch_retry.yaml
+++ b/tests/integration/scenarios/out_opentelemetry/config/out_otel_http_logs_batch_retry.yaml
@@ -1,0 +1,24 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+  scheduler.base: 1
+  scheduler.cap: 2
+
+pipeline:
+  inputs:
+    - name: ${TEST_LOG_INPUT}
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+  outputs:
+    - name: opentelemetry
+      match: "*"
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      grpc: off
+      http2: off
+      logs_uri: /v1/logs
+      batch_size: ${TEST_LOG_BATCH_SIZE}
+      retry_limit: no_limits

--- a/tests/integration/scenarios/out_opentelemetry/tests/test_out_opentelemetry_001.py
+++ b/tests/integration/scenarios/out_opentelemetry/tests/test_out_opentelemetry_001.py
@@ -2,9 +2,11 @@ import base64
 import json
 import logging
 import os
+import re
 import shutil
 import socket
 import threading
+from collections import Counter
 
 import requests
 import pytest
@@ -1109,6 +1111,133 @@ def test_out_opentelemetry_batch_size_splits_log_exports():
             for scope_log in resource_log.get("scopeLogs", [])
         )
         assert record_count == 1
+
+
+@pytest.mark.parametrize(
+    "input_name,batch_size,record_count,fail_request,status_code",
+    [
+        ("http", 1, 2, 0, 429),
+        ("http", 1, 2, 1, 429),
+        ("http", 1, 2, 2, 429),
+        ("http", 2, 5, 1, 429),
+        ("http", 2, 5, 2, 429),
+        ("http", 2, 5, 3, 429),
+        ("http", 2, 1, 1, 429),
+        ("http", 2, 2, 1, 429),
+        ("http", 1000, 2000, 1, 429),
+        ("http", 1000, 2000, 2, 429),
+        ("http", 1, 2, 1, 400),
+        ("http", 1, 2, 2, 400),
+        ("opentelemetry", 1, 2, 0, 429),
+        ("opentelemetry", 1, 2, 1, 429),
+        ("opentelemetry", 1, 2, 2, 429),
+    ],
+)
+def test_out_opentelemetry_log_batch_retry(
+    monkeypatch, input_name, batch_size, record_count, fail_request, status_code
+):
+    monkeypatch.setenv("TEST_LOG_INPUT", input_name)
+    monkeypatch.setenv("TEST_LOG_BATCH_SIZE", str(batch_size))
+    service = Service("out_otel_http_logs_batch_retry.yaml")
+    expected = [f"event-{index:06d}" for index in range(record_count)]
+    expected_batches = [expected[index:index + batch_size] for index in range(0, record_count, batch_size)]
+    statuses = [200] * (fail_request - 1) + [status_code] if fail_request else []
+    permanent_failure = bool(fail_request and status_code == 400)
+    retried = bool(fail_request and not permanent_failure)
+    service.start()
+    try:
+        configure_otlp_response(
+            status_codes=statuses,
+            body=b"",
+            content_type="application/x-protobuf",
+        )
+        if input_name == "opentelemetry":
+            service.send_payload_dict(
+                {"resource_logs": [
+                    _build_resource_collision_payload(event_id, event_id)["resource_logs"][0]
+                    for event_id in expected
+                ]},
+                "logs",
+            )
+        else:
+            response = requests.post(
+                f"http://127.0.0.1:{service.flb_listener_port}/repro",
+                json=[{"message": event_id} for event_id in expected],
+                timeout=5,
+            )
+            assert response.status_code == 201
+
+        def completed_metrics():
+            try:
+                response = requests.get(
+                    f"http://127.0.0.1:{service.flb.http_monitoring_port}/api/v1/metrics/prometheus",
+                    timeout=2,
+                )
+            except (requests.ConnectionError, requests.Timeout):
+                return None
+            response.raise_for_status()
+            counters = {
+                name: int(value)
+                for name, value in re.findall(
+                    r'^fluentbit_output_(\w+)\{name="opentelemetry\.0"\} (\d+)',
+                    response.text,
+                    re.MULTILINE,
+                )
+            }
+            finished = counters.get("proc_records_total", 0) + counters.get("dropped_records_total", 0)
+            return counters if finished == record_count else None
+
+        counters = service.service.wait_for_condition(
+            completed_metrics,
+            timeout=30,
+            description="completion of the whole log chunk",
+        )
+        _wait_for_log_message(service, "[task] destroy task=")
+        requests_seen = list(data_storage["logs"])
+    finally:
+        service.stop()
+
+    accepted = []
+    batches = []
+    for request_number, export_request in enumerate(requests_seen, start=1):
+        batch = [
+            record.body.string_value
+            for resource in export_request.resource_logs
+            for scope in resource.scope_logs
+            for record in scope.log_records
+        ]
+        assert 0 < len(batch) <= batch_size
+        batches.append(batch)
+        if request_number != fail_request:
+            accepted.extend(batch)
+
+    assert counters["proc_records_total"] == (0 if permanent_failure else record_count)
+    assert counters["retries_total"] == int(retried)
+    assert counters["retried_records_total"] == (record_count if retried else 0)
+    assert counters["errors_total"] == int(permanent_failure)
+    assert counters["dropped_records_total"] == (record_count if permanent_failure else 0)
+    if fail_request:
+        assert batches[fail_request - 1] == expected_batches[fail_request - 1]
+        attempted = expected_batches[:fail_request]
+        expected_accepted = expected[:(fail_request - 1) * batch_size]
+        if retried:
+            assert batches[fail_request] == expected_batches[0]
+            replayed = [event_id for batch in batches[fail_request:] for event_id in batch]
+            assert Counter(replayed) == Counter(expected)
+            attempted += expected_batches
+            expected_accepted += expected
+    else:
+        attempted = expected_batches
+        expected_accepted = expected
+    assert Counter(accepted) == Counter(expected_accepted)
+    assert Counter(map(tuple, batches)) == Counter(map(tuple, attempted))
+
+    with open(service.flb.log_file, encoding="utf-8") as log_file:
+        log = log_file.read()
+    created = re.findall(r"\[task\] created task=(\S+)", log)
+    destroyed = re.findall(r"\[task\] destroy task=(\S+)", log)
+    assert len(created) == 1
+    assert destroyed == created
 
 
 def test_out_opentelemetry_log_severity_message_keys():


### PR DESCRIPTION
Fixes #12384.

## Problem and fix

One input chunk can produce several OTLP log requests. If an earlier request
returns HTTP 429 and a later request succeeds, the later `FLB_OK` overwrites
`FLB_RETRY`. Fluent Bit releases the chunk without retrying the rejected logs.

Stop the batching loop on the first non-OK result, after resetting the freed
batch. The existing cleanup path then returns the failure to the engine.

With two records and `batch_size: 1`:

```text
Before: A -> 429, B -> 200. No retry; A is lost.
After:  A -> 429. Retry: A -> 200, B -> 200. Both arrive.
```

This retains whole-chunk retry: if A was accepted before B failed, A can be
duplicated on retry. It does not add exactly-once delivery, change HTTP status
classification, change retry limits, or modify the metrics/traces exporters.

A non-retryable result, such as HTTP 400, is also preserved: the engine drops
the chunk instead of reporting success. Later batches are not sent after that
failure. The tests cover both first- and last-batch HTTP 400 responses.

## Tests

The 15 new integration cases use either one JSON array sent to the HTTP input
or one native OTLP request containing separate resource groups. They decode
received OTLP payloads and check per-event delivery, complete batches, retries,
permanent failures, and creation/destruction of one task. The standalone
three-file reproduction remains available in the issue.

Local verification used Linux/arm64 in Docker. The patch was built on current
master (`f78472443d32691c319c424c75d9ea2343dbc8f7`) and on tag `v5.1.1`.

All 40 OpenTelemetry integration cases pass on patched master, both normally
and with strict Valgrind 3.18.1. All 40 memory reports show zero errors and no
remaining heap allocations. On the unpatched binary, seven of the 15 new cases
fail as expected and eight controls pass. A separate real integration run with
injected metrics `ConnectionError` and `Timeout` also passes.

Both DCO-signed commits pass the repository's commit-prefix checker over the
full PR range against `master`.

Commands run inside the development container, from `tests/integration`:

```bash
.venv/bin/python -m pytest scenarios/out_opentelemetry -q -o log_cli=false --tb=short
VALGRIND=1 VALGRIND_STRICT=1 .venv/bin/python -m pytest scenarios/out_opentelemetry -q -o log_cli=false --tb=short
```

From the repository root:

```bash
ctest --test-dir build -R '^flb-it-opentelemetry$' --output-on-failure
```

CTest result: 1/1 target passed. Representative Valgrind output (the same clean
summary was verified for all 40 tested processes):

```text
in use at exit: 0 bytes in 0 blocks
All heap blocks were freed -- no leaks are possible
ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

### Example test configuration

The integration harness provides the ports, `TEST_LOG_BATCH_SIZE`, and
`TEST_LOG_INPUT` (`http` or `opentelemetry`). Default body keys support both inputs.

```yaml
service:
  flush: 1
  grace: 1
  log_level: debug
  http_server: on
  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
  scheduler.base: 1
  scheduler.cap: 2

pipeline:
  inputs:
    - name: ${TEST_LOG_INPUT}
      port: ${FLUENT_BIT_TEST_LISTENER_PORT}

  outputs:
    - name: opentelemetry
      match: "*"
      host: 127.0.0.1
      port: ${TEST_SUITE_HTTP_PORT}
      grpc: off
      http2: off
      logs_uri: /v1/logs
      batch_size: ${TEST_LOG_BATCH_SIZE}
      retry_limit: no_limits
```

### Fixed 5.1.1 reproduction output

```text
Request 1: HTTP 429, 1 records, event-000000..event-000000
[debug] [retry] new retry created for task_id=0 attempts=1
Request 2: HTTP 200, 1 records, event-000000..event-000000
Request 3: HTTP 200, 1 records, event-000001..event-000001
[debug] [task] destroy task=0xf0cf7c0613d0 (task_id=0)
Engine successfully processed: 2
Receiver accepted: 2; missing: 0; duplicates: 0
Responses: [429, 200, 200]
```

The inverse order delivers both records with one duplicate. Both failure orders
also deliver all 2000 records with `batch_size: 1000`; an initial successful
batch produces 1000 duplicates on whole-chunk retry. Each case has one task.

## Submission checklist

**Testing**

- [x] Example configuration file for the change (above).
- [x] Debug log output from testing the change (above).
- [x] Valgrind output showing no leaks or memory corruption (above).
- [N/A] Run local packaging test: no packaging or build-system changes.
- [N/A] Set `ok-package-test` label: no packaging or build-system changes.

**Documentation**

- [N/A] Documentation required for this feature: no options added or changed.

**Backporting**

- [ ] Backport to latest stable release (not included in this PR).

Developed with AI assistance; verification used real local Fluent Bit processes
and a test receiver, not mocked delivery results.

Fluent Bit is licensed under Apache 2.0; by submitting this pull request I
understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OpenTelemetry log delivery error handling. When a batch flush fails, processing now stops promptly and preserves the failure result instead of allowing later batches to mask it.
  - Improved reliability for batched HTTP log delivery, including retry scenarios and failed requests.

- **Tests**
  - Added integration coverage for batching, retries, failure responses, dropped records, completion metrics, and request lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->