### PR TITLE
tests: runtime: Fix assertion failures on Ubuntu 26.04

### DIFF
--- a/tests/runtime/out_file_rotation.c
+++ b/tests/runtime/out_file_rotation.c
@@ -1433,14 +1433,16 @@ static void *thread_worker(void *arg)
     int bytes;
 
     for (i = 0; i < data->events_per_thread; i++) {
+        /* Records larger than PIPE_BUF can interleave on the shared input pipe. */
+        pthread_mutex_lock(data->mutex);
         bytes = flb_lib_push(data->ctx, data->in_ffd, data->json_data,
                              data->json_len);
         if (bytes != (int)data->json_len) {
-            pthread_mutex_lock(data->mutex);
             *data->success = 0;
             pthread_mutex_unlock(data->mutex);
             return NULL;
         }
+        pthread_mutex_unlock(data->mutex);
         flb_time_msleep(10);
     }
 
@@ -1462,10 +1464,11 @@ void flb_test_file_rotation_multithreaded(void)
     int success = 1;
     int num_threads = 4;
     int events_per_thread = 10;
-    FILE *fp;
     char *content;
+    char *pos;
     size_t content_size;
     int line_count = 0;
+    int key_count = 0;
 
     recursive_delete_directory(TEST_LOGPATH);
     TEST_MKDIR(TEST_LOGPATH);
@@ -1510,8 +1513,6 @@ void flb_test_file_rotation_multithreaded(void)
         pthread_join(threads[i], NULL);
     }
 
-    ret = wait_for_file_size(logfile, 100 * 1024, TEST_TIMEOUT_MS);
-    TEST_CHECK(ret == 0);
     TEST_CHECK(wait_for_output_records(ctx,
                                        num_threads * events_per_thread) == 0);
 
@@ -1520,30 +1521,26 @@ void flb_test_file_rotation_multithreaded(void)
 
     TEST_CHECK(success == 1);
 
-    fp = fopen(logfile, "r");
-    TEST_CHECK(fp != NULL);
-    if (fp) {
-        char line[4096];
-        while (fgets(line, sizeof(line), fp) != NULL) {
-            line_count++;
-        }
-        fclose(fp);
-    }
-
-    TEST_CHECK(line_count >= num_threads * events_per_thread);
-
     content = read_file_content(logfile, &content_size);
     TEST_CHECK(content != NULL);
     if (content) {
         TEST_CHECK(strstr(content, "test") != NULL);
         TEST_CHECK(strstr(content, "1448403340") != NULL);
-        int key_count = 0;
-        char *pos = content;
+
+        /* Count complete records, including lines longer than a read buffer. */
+        pos = content;
+        while ((pos = strchr(pos, '\n')) != NULL) {
+            line_count++;
+            pos++;
+        }
+        TEST_CHECK(line_count == num_threads * events_per_thread);
+
+        pos = content;
         while ((pos = strstr(pos, "key_0")) != NULL) {
             key_count++;
             pos++;
         }
-        TEST_CHECK(key_count >= num_threads * events_per_thread);
+        TEST_CHECK(key_count == num_threads * events_per_thread);
         flb_free(content);
     }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixed out_file_rotation.c. Concurrent 4,176-byte JSON writes exceeded the pipe’s atomic-write limit and could interleave. The test now serializes input writes, waits for processed records, and checks exactly 40 complete lines.

Verification:

- `ctest --test-dir build -R '^flb-rt-out_file(_rotation)?$' --output-on-failure` — both suites passed.
- `build/bin/flb-rt-out_file_rotation multithreaded` — passed 20 consecutive runs.
- Valgrind — passed with zero errors or lost allocations.
- Python integration — not run; no `out_file` scenario exists.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved multithreaded log rotation test reliability by preventing record interleaving during shared pipe writes.
  - Updated validation to count complete log contents and require exact line and record counts.
  - Removed an intermediate file-size wait check from the rotation test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->