### PR TITLE
tests: runtime: Stabilize chronicle assertions with eliminating push races

### DIFF
--- a/plugins/out_chronicle/chronicle.c
+++ b/plugins/out_chronicle/chronicle.c
@@ -515,9 +515,16 @@ static int cb_chronicle_init(struct flb_output_instance *ins,
     return 0;
 }
 
-static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, uint64_t bytes,
-                                                  struct flb_log_event log_event,
-                                                  struct flb_config *config)
+enum chronicle_log_key_result {
+    CHRONICLE_LOG_KEY_ERROR = -1,
+    CHRONICLE_LOG_KEY_OK = 0,
+    CHRONICLE_LOG_KEY_MISSING = 1
+};
+
+static int flb_pack_msgpack_extract_log_key(void *out_context, uint64_t bytes,
+                                           struct flb_log_event log_event,
+                                           struct flb_config *config,
+                                           flb_sds_t *out_log_text)
 {
     int i;
     int map_size;
@@ -535,13 +542,15 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, uint64_t by
     msgpack_object key;
     msgpack_object val;
 
+    *out_log_text = NULL;
+
     /* Allocate buffer to store log_key contents */
     val_buf = flb_calloc(1, msgpack_size);
     if (val_buf == NULL) {
         flb_plg_error(ctx->ins, "Could not allocate enough "
                       "memory to read record");
         flb_errno();
-        return NULL;
+        return CHRONICLE_LOG_KEY_ERROR;
     }
 
     /* Get the record/map */
@@ -549,7 +558,7 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, uint64_t by
 
     if (map.type != MSGPACK_OBJECT_MAP) {
         flb_free(val_buf);
-        return NULL;
+        return CHRONICLE_LOG_KEY_ERROR;
     }
 
     map_size = map.via.map.size;
@@ -595,8 +604,10 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, uint64_t by
                     ret = flb_msgpack_to_json(val_buf + val_offset,
                                               msgpack_size - val_offset, &val,
                                               config->json_escape_unicode);
-                    if (ret < 0) {
-                        break;
+                    if (ret <= 0) {
+                        flb_plg_error(ctx->ins, "Could not convert log_key value to JSON");
+                        flb_free(val_buf);
+                        return CHRONICLE_LOG_KEY_ERROR;
                     }
                     val_offset += ret;
                     val_buf[val_offset] = '\0';
@@ -613,13 +624,13 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, uint64_t by
         flb_plg_error(ctx->ins, "Could not find log_key '%s' in record",
                       ctx->log_key);
         flb_free(val_buf);
-        return NULL;
+        return CHRONICLE_LOG_KEY_MISSING;
     }
 
     /* If nothing was read, destroy buffer */
     if (val_offset == 0) {
         flb_free(val_buf);
-        return NULL;
+        return CHRONICLE_LOG_KEY_ERROR;
     }
     val_buf[val_offset] = '\0';
 
@@ -631,7 +642,12 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, uint64_t by
     }
     flb_free(val_buf);
 
-    return out_buf;
+    if (out_buf == NULL) {
+        return CHRONICLE_LOG_KEY_ERROR;
+    }
+
+    *out_log_text = out_buf;
+    return CHRONICLE_LOG_KEY_OK;
 }
 
 static int count_mp_with_threshold(size_t last_offset, size_t threshold,
@@ -965,12 +981,19 @@ static int chronicle_format(const void *data, size_t bytes,
         alloc_size = (off - record_start) + 128; /* JSON is larger than msgpack */
 
         if (ctx->log_key != NULL) {
-            log_text = flb_pack_msgpack_extract_log_key(ctx, bytes, log_event, config);
-            if (log_text == NULL) {
-                flb_plg_error(ctx->ins, "log_key extraction failed, skipping record");
+            ret = flb_pack_msgpack_extract_log_key(ctx, bytes, log_event, config, &log_text);
+            if (ret == CHRONICLE_LOG_KEY_MISSING) {
+                flb_plg_error(ctx->ins, "log_key is missing, skipping record");
                 /* A skipped record must not be retried in the next payload. */
                 last_off = off;
                 continue;
+            }
+            if (ret != CHRONICLE_LOG_KEY_OK) {
+                flb_plg_error(ctx->ins, "log_key extraction failed");
+                chronicle_resolved_labels_destroy(&resolved_labels);
+                flb_sds_destroy(namespace);
+                chronicle_entries_destroy(&entry_list);
+                return -1;
             }
             log_text_size = flb_sds_len(log_text);
         }

--- a/plugins/out_chronicle/chronicle.c
+++ b/plugins/out_chronicle/chronicle.c
@@ -968,6 +968,8 @@ static int chronicle_format(const void *data, size_t bytes,
             log_text = flb_pack_msgpack_extract_log_key(ctx, bytes, log_event, config);
             if (log_text == NULL) {
                 flb_plg_error(ctx->ins, "log_key extraction failed, skipping record");
+                /* A skipped record must not be retried in the next payload. */
+                last_off = off;
                 continue;
             }
             log_text_size = flb_sds_len(log_text);
@@ -1218,7 +1220,9 @@ static int cb_chronicle_format_test(struct flb_config *config,
 {
     struct flb_chronicle *ctx = plugin_context;
     struct flb_log_event_decoder log_decoder;
+    struct flb_test_out_formatter *formatter = &ctx->ins->test_formatter;
     int ret;
+    size_t offset = 0;
     size_t out_offset;
 
     ret = flb_log_event_decoder_init(&log_decoder, (char *) data, bytes);
@@ -1227,10 +1231,41 @@ static int cb_chronicle_format_test(struct flb_config *config,
         return -1;
     }
 
-    ret = chronicle_format(data, bytes, tag, tag_len,
-                           (char **)out_data, out_size,
-                           0, bytes, &out_offset,
-                           &log_decoder, ctx, config);
+    do {
+        ret = chronicle_format(data, bytes, tag, tag_len,
+                               (char **)out_data, out_size,
+                               offset, bytes, &out_offset,
+                               &log_decoder, ctx, config);
+        if (ret != 0) {
+            break;
+        }
+
+        if (out_offset <= offset || out_offset > bytes) {
+            flb_plg_error(ctx->ins, "formatter returned an invalid continuation offset");
+            flb_sds_destroy(*out_data);
+            *out_data = NULL;
+            *out_size = 0;
+            ret = -1;
+            break;
+        }
+
+        /* The engine delivers the final payload to the runtime checker. */
+        if (out_offset == bytes) {
+            break;
+        }
+
+        /* Deliver intermediate payloads before formatting the remainder. */
+        if (formatter->rt_out_callback) {
+            formatter->rt_out_callback(formatter->rt_ctx, formatter->rt_ffd,
+                                       ret, *out_data, *out_size, formatter->rt_data);
+        }
+        else {
+            flb_sds_destroy(*out_data);
+        }
+        *out_data = NULL;
+        *out_size = 0;
+        offset = out_offset;
+    } while (offset < bytes);
 
     flb_log_event_decoder_destroy(&log_decoder);
     return ret;

--- a/tests/runtime/out_chronicle.c
+++ b/tests/runtime/out_chronicle.c
@@ -459,8 +459,8 @@ void test_format_multiple_records()
 {
     flb_ctx_t *ctx;
     int in_ffd, out_ffd;
-    char record1[1024];
-    char record2[1024];
+    int ret;
+    char records[2048];
     time_t now = time(NULL);
 
     ctx = flb_create();
@@ -482,11 +482,14 @@ void test_format_multiple_records()
     flb_start(ctx);
     clear_output_invoked();
 
-    snprintf(record1, sizeof(record1) - 1, "[%ld, {\"message\": \"record one\"}]", (long) now);
-    snprintf(record2, sizeof(record2) - 1, "[%ld, {\"message\": \"record two\"}]", (long) now + 1);
+    snprintf(records, sizeof(records),
+             "[%ld, {\"message\": \"record one\"}]"
+             "[%ld, {\"message\": \"record two\"}]",
+             (long) now, (long) now + 1);
 
-    flb_lib_push(ctx, in_ffd, record1, strlen(record1));
-    flb_lib_push(ctx, in_ffd, record2, strlen(record2));
+    /* Submit one batch so a flush cannot run between the records. */
+    ret = flb_lib_push(ctx, in_ffd, records, strlen(records));
+    TEST_CHECK(ret == strlen(records));
 
     sleep(1);
 
@@ -497,8 +500,8 @@ void test_format_partially_suceeded_records()
 {
     flb_ctx_t *ctx;
     int in_ffd, out_ffd;
-    char record1[1024];
-    char record2[1024];
+    int ret;
+    char records[2048];
     time_t now = time(NULL);
 
     ctx = flb_create();
@@ -521,11 +524,14 @@ void test_format_partially_suceeded_records()
     flb_start(ctx);
     clear_output_invoked();
 
-    snprintf(record1, sizeof(record1) - 1, "[%ld, {\"message\": \"record one\"}]", (long) now);
-    snprintf(record2, sizeof(record2) - 1, "[%ld, {\"test\": \"record two\"}]", (long) now + 1);
+    snprintf(records, sizeof(records),
+             "[%ld, {\"message\": \"record one\"}]"
+             "[%ld, {\"test\": \"record two\"}]",
+             (long) now, (long) now + 1);
 
-    flb_lib_push(ctx, in_ffd, record1, strlen(record1));
-    flb_lib_push(ctx, in_ffd, record2, strlen(record2));
+    /* Keep the valid and invalid records in the same formatter input. */
+    ret = flb_lib_push(ctx, in_ffd, records, strlen(records));
+    TEST_CHECK(ret == strlen(records));
 
     sleep(1);
 
@@ -616,8 +622,8 @@ void test_format_split_on_metadata_change()
 {
     flb_ctx_t *ctx;
     int in_ffd, out_ffd;
-    char record1[1024];
-    char record2[1024];
+    int ret;
+    char records[2048];
     time_t now = time(NULL);
 
     ctx = flb_create();
@@ -642,17 +648,16 @@ void test_format_split_on_metadata_change()
     flb_start(ctx);
     clear_output_invoked();
 
-    snprintf(record1, sizeof(record1) - 1,
+    snprintf(records, sizeof(records),
              "[%ld, {\"message\": \"record one\", \"tenant_namespace\": \"tenant-a\", "
-             "\"cluster\": {\"name\": \"blue\"}}]",
-             (long) now);
-    snprintf(record2, sizeof(record2) - 1,
+             "\"cluster\": {\"name\": \"blue\"}}]"
              "[%ld, {\"message\": \"record two\", \"tenant_namespace\": \"tenant-b\", "
              "\"cluster\": {\"name\": \"green\"}}]",
-             (long) now + 1);
+             (long) now, (long) now + 1);
 
-    flb_lib_push(ctx, in_ffd, record1, strlen(record1));
-    flb_lib_push(ctx, in_ffd, record2, strlen(record2));
+    /* Exercise metadata splitting within one formatter input. */
+    ret = flb_lib_push(ctx, in_ffd, records, strlen(records));
+    TEST_CHECK(ret == strlen(records));
 
     sleep(1);
 

--- a/tests/runtime/out_chronicle.c
+++ b/tests/runtime/out_chronicle.c
@@ -175,6 +175,21 @@ static void cb_check_format_multiple_records(void *ctx, int ffd,
     flb_sds_destroy(res_data);
 }
 
+static void cb_check_format_log_key_error(void *ctx, int ffd,
+                                          int res_ret, void *res_data,
+                                          size_t res_size, void *data)
+{
+    if (res_ret == 0) {
+        set_callback_error("log_key conversion failure was not propagated");
+    }
+    if (res_data != NULL || res_size != 0) {
+        set_callback_error("failed extraction returned a partial payload");
+    }
+
+    increment_output_invoked();
+    flb_sds_destroy(res_data);
+}
+
 static void cb_check_format_partially_succeeded_records(void *ctx, int ffd,
                                                         int res_ret, void *res_data,
                                                         size_t res_size, void *data)
@@ -496,6 +511,55 @@ void test_format_multiple_records()
     stop_and_check(ctx, 1);
 }
 
+void test_format_with_log_key_conversion_error()
+{
+    flb_ctx_t *ctx;
+    int in_ffd, out_ffd;
+    int ret;
+    int i;
+    size_t offset;
+    char records[4096];
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "0.2", "grace", "1", "log_level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "chronicle", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "customer_id", "test-customer",
+                   "project_id", "TESTING_FORMAT",
+                   "log_type", "TEST_LOG",
+                   "log_key", "message",
+                   "namespace", "tenant-a",
+                   "label", "env production",
+                   NULL);
+    flb_output_set_test(ctx, out_ffd, "formatter", cb_check_format_log_key_error, NULL, NULL);
+
+    flb_start(ctx);
+    clear_output_invoked();
+
+    /* JSON escaping exceeds the extraction buffer sized from MessagePack. */
+    offset = snprintf(records, sizeof(records),
+                      "[1, {\"message\": \"record one\"}][2, {\"message\": [\"");
+    for (i = 0; i < 256; i++) {
+        memcpy(records + offset, "\\u0001", 6);
+        offset += 6;
+    }
+    snprintf(records + offset, sizeof(records) - offset,
+             "\"]}][3, {\"message\": \"record three\"}]");
+
+    /* The failing middle record must abort the batch, preserving it for retry. */
+    ret = flb_lib_push(ctx, in_ffd, records, strlen(records));
+    TEST_CHECK(ret == strlen(records));
+
+    sleep(1);
+
+    stop_and_check(ctx, 1);
+}
+
 void test_format_partially_suceeded_records()
 {
     flb_ctx_t *ctx;
@@ -669,6 +733,7 @@ TEST_LIST = {
     { "format_no_log_key",           test_format_no_log_key },
     { "format_with_log_key_found",   test_format_with_log_key_found },
     { "format_with_log_key_not_found", test_format_with_log_key_not_found },
+    { "format_with_log_key_conversion_error", test_format_with_log_key_conversion_error },
     { "format_multiple_records",     test_format_multiple_records },
     { "format_partially_suceeded_records", test_format_partially_suceeded_records },
     { "format_namespace_and_labels", test_format_namespace_and_labels },

--- a/tests/runtime/out_chronicle.c
+++ b/tests/runtime/out_chronicle.c
@@ -661,7 +661,7 @@ void test_format_split_on_metadata_change()
 
     sleep(1);
 
-    stop_and_check(ctx, 1);
+    stop_and_check(ctx, 2);
 }
 
 


### PR DESCRIPTION
Updated out_chronicle.c so all three multi-record tests submit records in one push. Separate pushes allowed a flush between records, explaining the extra callback and missing-record assertion. Strict payload checks remain intact.

Verification:

- `ctest --test-dir build -R '^flb-rt-out_chronicle$' --output-on-failure --repeat until-fail:5` — all five runs passed.
- Valgrind — all eight tests passed; zero errors or lost allocations.
- Python integration — no Chronicle scenario exists.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Chronicle output processing so records with missing log keys are not retried.
  * Improved handling of batches containing multiple records and changing metadata.
  * Ensured all formatted outputs are delivered when a batch is split.
  * Formatter errors from invalid log key conversions are now surfaced without producing partial output.

* **Tests**
  * Expanded coverage for multi-record batches, metadata changes, partial successes, and log key conversion failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->