### PR TITLE
out_gcs: fix networking and worker crashes, add total_file_size

### DIFF
--- a/plugins/out_gcs/gcs.c
+++ b/plugins/out_gcs/gcs.c
@@ -1612,18 +1612,19 @@ static int process_upload_queue(struct flb_gcs *ctx)
             gcs_store_file_delete(ctx, entry->upload_file);
             flb_free(buffer);
             remove_from_queue(entry);
-            if (ctx->preserve_data_ordering == FLB_TRUE) {
-                break;
-            }
         }
         else {
             flb_free(buffer);
             gcs_store_file_unlock(entry->upload_file);
             entry->retry_counter++;
             entry->upload_time = now + (2 * entry->retry_counter);
-            if (ctx->preserve_data_ordering == FLB_TRUE) {
-                break;
-            }
+            /*
+             * Stop the pass at the first failure in both modes: uploads run
+             * in sync mode, so every additional attempt against a failing
+             * endpoint blocks the calling thread for another connect
+             * timeout. Remaining entries are retried on the next pass.
+             */
+            break;
         }
     }
 
@@ -1711,7 +1712,9 @@ static void cb_gcs_upload(struct flb_config *config, void *data)
         return;
     }
 
+    pthread_mutex_lock(&ctx->upload_lock);
     process_upload_queue(ctx);
+    pthread_mutex_unlock(&ctx->upload_lock);
 }
 
 
@@ -1845,6 +1848,12 @@ static int cb_gcs_init(struct flb_output_instance *ins, struct flb_config *confi
     }
     ctx->ins = ins; ctx->config = config;
     mk_list_init(&ctx->upload_queue);
+    if (pthread_mutex_init(&ctx->upload_lock, NULL) != 0) {
+        flb_errno();
+        flb_free(ctx);
+        return -1;
+    }
+    ctx->upload_lock_initialized = FLB_TRUE;
     ctx->retry_time = 0;
     ctx->upload_queue_success = FLB_FALSE;
     ctx->timer_created = FLB_FALSE;
@@ -2091,27 +2100,22 @@ error:
     return -1;
 }
 
-static void cb_gcs_flush(struct flb_event_chunk *event_chunk, struct flb_output_flush *out_flush,
-                         struct flb_input_instance *i_ins, void *out_context, struct flb_config *config)
+/*
+ * Buffer the payload in the local store and process the upload queue.
+ * Must be called with ctx->upload_lock held; returns an FLB_OUTPUT_RETURN
+ * status code.
+ */
+static int gcs_flush_payload(struct flb_gcs *ctx,
+                             struct flb_event_chunk *event_chunk,
+                             flb_sds_t payload)
 {
-    struct flb_gcs *ctx = out_context;
-    flb_sds_t payload;
     flb_sds_t tag_name = NULL;
     int tag_name_len;
     int ret;
     struct gcs_file *chunk;
 
     if (flush_init(ctx) == -1) {
-        FLB_OUTPUT_RETURN(FLB_RETRY);
-    }
-    (void) out_flush;
-    (void) i_ins;
-
-    payload = flb_pack_msgpack_to_json_format(event_chunk->data, event_chunk->size,
-                                              ctx->out_format, ctx->json_date_format,
-                                              ctx->json_date_key, config->json_escape_unicode);
-    if (!payload) {
-        FLB_OUTPUT_RETURN(FLB_RETRY);
+        return FLB_RETRY;
     }
 
     if (ctx->unify_tag == FLB_TRUE) {
@@ -2130,40 +2134,68 @@ static void cb_gcs_flush(struct flb_event_chunk *event_chunk, struct flb_output_
         chunk->size + flb_sds_len(payload) > ctx->total_file_size) {
         ret = seal_and_queue_for_upload(ctx, chunk, tag_name, tag_name_len);
         if (ret == -1) {
-            flb_sds_destroy(payload);
-            FLB_OUTPUT_RETURN(FLB_RETRY);
+            return FLB_RETRY;
         }
         chunk = NULL;
     }
 
     if (gcs_store_buffer_put(ctx, chunk, tag_name, tag_name_len,
                              payload, flb_sds_len(payload)) == -1) {
-        flb_sds_destroy(payload);
-        FLB_OUTPUT_RETURN(FLB_RETRY);
+        return FLB_RETRY;
     }
-    flb_sds_destroy(payload);
 
     chunk = gcs_store_file_get(ctx, tag_name, tag_name_len);
     if (!chunk) {
-        FLB_OUTPUT_RETURN(FLB_RETRY);
+        return FLB_RETRY;
     }
 
     ret = add_to_queue(ctx, chunk, tag_name, tag_name_len);
     if (ret == -1) {
+        return FLB_RETRY;
+    }
+
+    /*
+     * Non-order-preserving mode: try to flush every due queue entry.
+     * Preserve-order mode: flush due entries strictly in FIFO order and
+     * stop at the first failure.
+     */
+    ret = process_upload_queue(ctx);
+    if (ret == -1) {
+        return FLB_ERROR;
+    }
+
+    return FLB_OK;
+}
+
+static void cb_gcs_flush(struct flb_event_chunk *event_chunk, struct flb_output_flush *out_flush,
+                         struct flb_input_instance *i_ins, void *out_context, struct flb_config *config)
+{
+    struct flb_gcs *ctx = out_context;
+    flb_sds_t payload;
+    int ret;
+
+    (void) out_flush;
+    (void) i_ins;
+
+    payload = flb_pack_msgpack_to_json_format(event_chunk->data, event_chunk->size,
+                                              ctx->out_format, ctx->json_date_format,
+                                              ctx->json_date_key, config->json_escape_unicode);
+    if (!payload) {
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }
 
     /*
-     * Non-order-preserving mode: try to flush as many queued entries as possible.
-     * Preserve-order mode: process at most one queue entry per flush to keep
-     * strict FIFO progression.
+     * Flushes may run concurrently from several workers, and the upload
+     * timer runs in one of them: serialize all access to the upload queue,
+     * the local file store and the sequence index. The upstream is in sync
+     * mode, so no coroutine switch happens while the lock is held.
      */
-    ret = process_upload_queue(ctx);
-    if (ret == -1) {
-        FLB_OUTPUT_RETURN(FLB_ERROR);
-    }
+    pthread_mutex_lock(&ctx->upload_lock);
+    ret = gcs_flush_payload(ctx, event_chunk, payload);
+    pthread_mutex_unlock(&ctx->upload_lock);
 
-    FLB_OUTPUT_RETURN(FLB_OK);
+    flb_sds_destroy(payload);
+    FLB_OUTPUT_RETURN(ret);
 }
 
 static int gcs_ctx_destroy(void *data, struct flb_config *config)
@@ -2233,6 +2265,9 @@ static int gcs_ctx_destroy(void *data, struct flb_config *config)
 
     if (ctx->token_mutex_initialized == FLB_TRUE) {
         pthread_mutex_destroy(&ctx->token_mutex);
+    }
+    if (ctx->upload_lock_initialized == FLB_TRUE) {
+        pthread_mutex_destroy(&ctx->upload_lock);
     }
     flb_free(ctx);
 

--- a/plugins/out_gcs/gcs.c
+++ b/plugins/out_gcs/gcs.c
@@ -1957,6 +1957,9 @@ static int cb_gcs_init(struct flb_output_instance *ins, struct flb_config *confi
     if (!ctx->u) {
         goto error;
     }
+    /* apply net.* properties (keepalive, timeouts, ...) to the upstream */
+    flb_output_upstream_set(ctx->u, ins);
+
     if (ctx->metadata_server_auth == FLB_TRUE) {
         ctx->metadata_u = flb_upstream_create_url(config, ctx->metadata_server,
                                                   FLB_IO_TCP, NULL);

--- a/plugins/out_gcs/gcs.c
+++ b/plugins/out_gcs/gcs.c
@@ -1196,6 +1196,36 @@ static void remove_from_queue(struct upload_queue *entry)
     flb_free(entry);
 }
 
+/*
+ * Seal a buffered file that reached total_file_size: no more data is
+ * appended to it and its queue entry becomes due immediately.
+ */
+static int seal_and_queue_for_upload(struct flb_gcs *ctx, struct gcs_file *chunk,
+                                     const char *tag, int tag_len)
+{
+    struct mk_list *head;
+    struct upload_queue *entry;
+
+    if (add_to_queue(ctx, chunk, tag, tag_len) == -1) {
+        return -1;
+    }
+
+    gcs_store_file_seal(chunk);
+
+    mk_list_foreach(head, &ctx->upload_queue) {
+        entry = mk_list_entry(head, struct upload_queue, _head);
+        if (entry->upload_file == chunk) {
+            entry->upload_time = time(NULL);
+            break;
+        }
+    }
+
+    flb_plg_debug(ctx->ins,
+                  "total_file_size reached for tag %.*s (%zu bytes), "
+                  "scheduling upload", tag_len, tag, chunk->size);
+    return 0;
+}
+
 
 static void clear_upload_queue(struct flb_gcs *ctx)
 {
@@ -1840,6 +1870,13 @@ static int cb_gcs_init(struct flb_output_instance *ins, struct flb_config *confi
         goto error;
     }
 
+    if (ctx->total_file_size != 0 &&
+        ctx->total_file_size < FLB_GCS_MIN_TOTAL_FILE_SIZE) {
+        flb_plg_error(ins, "'total_file_size' must be at least 1M "
+                      "(or 0 to disable the size trigger)");
+        goto error;
+    }
+
     ctx->timer_ms = ctx->upload_timeout / 6;
     if (ctx->timer_ms >= 60) {
         ctx->timer_ms = 60000;
@@ -2087,6 +2124,18 @@ static void cb_gcs_flush(struct flb_event_chunk *event_chunk, struct flb_output_
     }
 
     chunk = gcs_store_file_get(ctx, tag_name, tag_name_len);
+
+    /* total_file_size reached: upload the current file, start a new one */
+    if (chunk && ctx->total_file_size > 0 &&
+        chunk->size + flb_sds_len(payload) > ctx->total_file_size) {
+        ret = seal_and_queue_for_upload(ctx, chunk, tag_name, tag_name_len);
+        if (ret == -1) {
+            flb_sds_destroy(payload);
+            FLB_OUTPUT_RETURN(FLB_RETRY);
+        }
+        chunk = NULL;
+    }
+
     if (gcs_store_buffer_put(ctx, chunk, tag_name, tag_name_len,
                              payload, flb_sds_len(payload)) == -1) {
         flb_sds_destroy(payload);
@@ -2233,6 +2282,13 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_TIME, "upload_timeout", "10m",
      0, FLB_TRUE, offsetof(struct flb_gcs, upload_timeout),
      "Upload timeout before chunk is flushed."
+    },
+    {
+     FLB_CONFIG_MAP_SIZE, "total_file_size", "100M",
+     0, FLB_TRUE, offsetof(struct flb_gcs, total_file_size),
+     "Maximum size of buffered data per tag before it is uploaded as an "
+     "object, even if upload_timeout has not elapsed yet. Minimum 1M, "
+     "0 disables the size trigger."
     },
     {
      FLB_CONFIG_MAP_BOOL, "send_content_md5", "false",

--- a/plugins/out_gcs/gcs.c
+++ b/plugins/out_gcs/gcs.c
@@ -1265,6 +1265,11 @@ static int construct_request_buffer(struct flb_gcs *ctx,
 {
     int ret;
 
+    if (gcs_under_test_mode() == FLB_TRUE &&
+        getenv("TEST_GCS_CONSTRUCT_REQUEST_BUFFER_ERROR") != NULL) {
+        return -1;
+    }
+
     ret = gcs_store_file_read(ctx, entry->upload_file, out_buffer, out_size);
     if (ret == -1) {
         return -1;
@@ -1579,9 +1584,8 @@ static int process_upload_queue(struct flb_gcs *ctx)
     time_t now;
 
     /*
-     * Uploads can yield while waiting for network I/O. Do not let the periodic
-     * timer re-enter this function and process the same queue entry while an
-     * output flush is still handling it.
+     * Queue processing runs during initialization or with upload_lock held.
+     * Keep the re-entry guard so an entry cannot be processed twice.
      */
     if (ctx->upload_queue_processing == FLB_TRUE) {
         return 0;
@@ -1603,7 +1607,8 @@ static int process_upload_queue(struct flb_gcs *ctx)
         if (ret == -1) {
             gcs_store_file_unlock(entry->upload_file);
             entry->retry_counter++;
-            continue;
+            entry->upload_time = now + (2 * entry->retry_counter);
+            break;
         }
 
         ret = upload_data(ctx, entry, buffer, buffer_size);
@@ -1619,10 +1624,8 @@ static int process_upload_queue(struct flb_gcs *ctx)
             entry->retry_counter++;
             entry->upload_time = now + (2 * entry->retry_counter);
             /*
-             * Stop the pass at the first failure in both modes: uploads run
-             * in sync mode, so every additional attempt against a failing
-             * endpoint blocks the calling thread for another connect
-             * timeout. Remaining entries are retried on the next pass.
+             * Stop after a failed upload so the next pass can retry it
+             * without blocking this thread on more network requests.
              */
             break;
         }
@@ -1662,6 +1665,8 @@ static int attach_recovered_chunk(struct flb_gcs *ctx, struct flb_fstore_file *f
 
     chunk->fsf = fsf;
     chunk->size = size;
+    /* Recovered files are pending uploads, not buffers for new records. */
+    gcs_store_file_seal(chunk);
 
     if (ctx->upload_timeout > 0) {
         chunk->create_time = time(NULL) - ctx->upload_timeout;
@@ -2149,7 +2154,12 @@ static int gcs_flush_payload(struct flb_gcs *ctx,
         return FLB_RETRY;
     }
 
-    ret = add_to_queue(ctx, chunk, tag_name, tag_name_len);
+    if (ctx->total_file_size > 0 && chunk->size >= ctx->total_file_size) {
+        ret = seal_and_queue_for_upload(ctx, chunk, tag_name, tag_name_len);
+    }
+    else {
+        ret = add_to_queue(ctx, chunk, tag_name, tag_name_len);
+    }
     if (ret == -1) {
         return FLB_RETRY;
     }
@@ -2206,10 +2216,8 @@ static int gcs_ctx_destroy(void *data, struct flb_config *config)
     }
 
     /*
-     * Uploads require an output worker coroutine. The exit callback runs after
-     * the workers have stopped, so attempting an upload here can switch to an
-     * invalid coroutine/fiber context. Leave pending chunks in the file store;
-     * they are recovered and uploaded on the next startup.
+     * Leave pending chunks in the file store for recovery on the next startup.
+     * Synchronous network requests here would delay shutdown.
      */
     clear_upload_queue(ctx);
 
@@ -2321,9 +2329,9 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_SIZE, "total_file_size", "100M",
      0, FLB_TRUE, offsetof(struct flb_gcs, total_file_size),
-     "Maximum size of buffered data per tag before it is uploaded as an "
-     "object, even if upload_timeout has not elapsed yet. Minimum 1M, "
-     "0 disables the size trigger."
+     "Buffered data size per tag that triggers an upload before upload_timeout. "
+     "Batches are not split, so objects can exceed this size. Minimum 1M, "
+     "0 disables the size trigger. Ordered uploads still wait for older files."
     },
     {
      FLB_CONFIG_MAP_BOOL, "send_content_md5", "false",

--- a/plugins/out_gcs/gcs.c
+++ b/plugins/out_gcs/gcs.c
@@ -1685,30 +1685,6 @@ static void cb_gcs_upload(struct flb_config *config, void *data)
 }
 
 
-static void gcs_upload_queue(struct flb_config *config, void *data)
-{
-    int async_flags;
-    struct flb_gcs *ctx = data;
-
-    (void) config;
-
-    if (!ctx) {
-        return;
-    }
-
-    if (mk_list_size(&ctx->upload_queue) == 0) {
-        cb_gcs_upload(config, data);
-        return;
-    }
-
-    async_flags = flb_stream_get_flags(&ctx->u->base);
-    flb_stream_disable_async_mode(&ctx->u->base);
-
-    process_upload_queue(ctx);
-
-    flb_stream_set_flags(&ctx->u->base, async_flags);
-}
-
 static int flush_init(struct flb_gcs *ctx)
 {
     int ret;
@@ -1723,14 +1699,8 @@ static int flush_init(struct flb_gcs *ctx)
         return -1;
     }
 
-    if (ctx->preserve_data_ordering == FLB_TRUE) {
-        ret = flb_sched_timer_cb_create(sched, FLB_SCHED_TIMER_CB_PERM,
-                                        ctx->timer_ms, gcs_upload_queue, ctx, NULL);
-    }
-    else {
-        ret = flb_sched_timer_cb_create(sched, FLB_SCHED_TIMER_CB_PERM,
-                                        ctx->timer_ms, cb_gcs_upload, ctx, NULL);
-    }
+    ret = flb_sched_timer_cb_create(sched, FLB_SCHED_TIMER_CB_PERM,
+                                    ctx->timer_ms, cb_gcs_upload, ctx, NULL);
     if (ret == -1) {
         return -1;
     }
@@ -1959,6 +1929,20 @@ static int cb_gcs_init(struct flb_output_instance *ins, struct flb_config *confi
     }
     /* apply net.* properties (keepalive, timeouts, ...) to the upstream */
     flb_output_upstream_set(ctx->u, ins);
+
+    /*
+     * The upstream must ALWAYS run in sync mode: uploads are also triggered
+     * from the scheduler timer callback (and from init when a backlog is
+     * recovered), which run outside of any coroutine. An async write from
+     * there would try to yield a NULL coroutine and crash.
+     */
+    flb_stream_disable_async_mode(&ctx->u->base);
+
+    if (ins->tp_workers < 1) {
+        flb_plg_warn(ins, "uploads use synchronous network I/O; running "
+                     "with 'workers 0' will block the main event loop, "
+                     "configure 'workers 1' or higher");
+    }
 
     if (ctx->metadata_server_auth == FLB_TRUE) {
         ctx->metadata_u = flb_upstream_create_url(config, ctx->metadata_server,

--- a/plugins/out_gcs/gcs.h
+++ b/plugins/out_gcs/gcs.h
@@ -35,6 +35,7 @@
 #define FLB_GCS_METADATA_TOKEN_URI \
     "/computeMetadata/v1/instance/service-accounts/default/token"
 #define FLB_GCS_METADATA_TOKEN_SIZE_MAX 14336
+#define FLB_GCS_MIN_TOTAL_FILE_SIZE 1000000
 
 /* refresh federation tokens this many seconds before their server-stated expiry */
 #define FLB_GCS_TOKEN_EXPIRY_SAFETY 300
@@ -120,6 +121,7 @@ struct flb_gcs {
     flb_sds_t fs_stream_name;
     struct mk_list upload_queue;
     time_t upload_timeout;
+    size_t total_file_size;
     int retry_time;
     int upload_queue_success;
     int upload_queue_processing;

--- a/plugins/out_gcs/gcs.h
+++ b/plugins/out_gcs/gcs.h
@@ -89,6 +89,9 @@ struct flb_gcs {
     struct flb_oauth2 *o;
     pthread_mutex_t token_mutex;
     int token_mutex_initialized;
+    /* serializes access to the upload queue / file store across workers */
+    pthread_mutex_t upload_lock;
+    int upload_lock_initialized;
     int metadata_server_auth;
 
     flb_sds_t bucket;

--- a/plugins/out_gcs/gcs_store.c
+++ b/plugins/out_gcs/gcs_store.c
@@ -163,7 +163,7 @@ struct gcs_file *gcs_store_file_get(struct flb_gcs *ctx, const char *tag, int ta
         }
 
         chunk = fsf->data;
-        if (!chunk || chunk->locked == FLB_TRUE) {
+        if (!chunk || chunk->locked == FLB_TRUE || chunk->sealed == FLB_TRUE) {
             continue;
         }
         if (strncmp(fsf->meta_buf, tag, tag_len) == 0) {
@@ -262,6 +262,11 @@ void gcs_store_file_lock(struct gcs_file *chunk)
 void gcs_store_file_unlock(struct gcs_file *chunk)
 {
     chunk->locked = FLB_FALSE;
+}
+
+void gcs_store_file_seal(struct gcs_file *chunk)
+{
+    chunk->sealed = FLB_TRUE;
 }
 
 int gcs_store_file_delete(struct flb_gcs *ctx, struct gcs_file *chunk)

--- a/plugins/out_gcs/gcs_store.h
+++ b/plugins/out_gcs/gcs_store.h
@@ -30,6 +30,8 @@ struct gcs_file {
     flb_sds_t file_path;
     size_t size;
     int locked;
+    /* total_file_size reached: no more appends, pending upload */
+    int sealed;
     int failures;
     time_t create_time;
 };
@@ -44,6 +46,7 @@ int gcs_store_file_read(struct flb_gcs *ctx, struct gcs_file *chunk,
                         char **out_buf, size_t *out_size);
 void gcs_store_file_lock(struct gcs_file *chunk);
 void gcs_store_file_unlock(struct gcs_file *chunk);
+void gcs_store_file_seal(struct gcs_file *chunk);
 int gcs_store_file_delete(struct flb_gcs *ctx, struct gcs_file *chunk);
 
 #endif

--- a/tests/runtime/out_gcs.c
+++ b/tests/runtime/out_gcs.c
@@ -1345,6 +1345,179 @@ void flb_test_gcs_workers_upload_all_tags(void)
     flb_free(store_dir);
 }
 
+/*
+ * Data left in store_dir by a previous run must be recovered and uploaded
+ * shortly after startup (the recovery path runs from init and from the
+ * upload timer, both outside of any flush coroutine).
+ */
+void flb_test_gcs_recovers_backlog_on_restart(void)
+{
+    int ret;
+    int in_ffd;
+    int out_ffd;
+    int call_count;
+    char *call_count_str;
+    char *store_dir;
+    flb_ctx_t *ctx;
+
+    store_dir = create_test_store_directory("/flb-gcs-test-backlog-XXXXXX");
+    TEST_CHECK(store_dir != NULL);
+    if (!store_dir) {
+        return;
+    }
+
+    setenv("FLB_GCS_PLUGIN_UNDER_TEST", "true", 1);
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+
+    /* first instance: buffer data but never reach upload_timeout */
+    ctx = flb_create();
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "gcs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+    flb_output_set(ctx, out_ffd, "bucket", "fluent", NULL);
+    flb_output_set(ctx, out_ffd, "google_service_credentials", SERVICE_CREDENTIALS, NULL);
+    flb_output_set(ctx, out_ffd, "store_dir", store_dir, NULL);
+    flb_output_set(ctx, out_ffd, "upload_timeout", "10m", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        flb_destroy(ctx);
+        unsetenv("FLB_GCS_PLUGIN_UNDER_TEST");
+        flb_free(store_dir);
+        return;
+    }
+
+    flb_lib_push(ctx, in_ffd, (char *) JSON_TD, (int) sizeof(JSON_TD) - 1);
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    call_count_str = getenv("TEST_GCS_UploadObject_CALL_COUNT");
+    call_count = call_count_str ? atoi(call_count_str) : 0;
+    TEST_CHECK_(call_count == 0,
+                "Expected no upload before shutdown, got %d", call_count);
+
+    /* second instance on the same store_dir: backlog must be uploaded */
+    ctx = flb_create();
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "gcs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+    flb_output_set(ctx, out_ffd, "bucket", "fluent", NULL);
+    flb_output_set(ctx, out_ffd, "google_service_credentials", SERVICE_CREDENTIALS, NULL);
+    flb_output_set(ctx, out_ffd, "store_dir", store_dir, NULL);
+    flb_output_set(ctx, out_ffd, "upload_timeout", "10m", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    if (ret == 0) {
+        sleep(3);
+        call_count_str = getenv("TEST_GCS_UploadObject_CALL_COUNT");
+        call_count = call_count_str ? atoi(call_count_str) : 0;
+        TEST_CHECK_(call_count == 1,
+                    "Expected recovered backlog to be uploaded once, got %d",
+                    call_count);
+        flb_stop(ctx);
+    }
+    flb_destroy(ctx);
+
+    unsetenv("FLB_GCS_PLUGIN_UNDER_TEST");
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+    unsetenv("TEST_GCS_LAST_URI");
+    unsetenv("TEST_GCS_LAST_BODY_GZIP");
+    flb_free(store_dir);
+}
+
+/* total_file_size must also apply to the shared file used by unify_tag */
+void flb_test_gcs_total_file_size_with_unify_tag(void)
+{
+    int i;
+    int ret;
+    int in_ffd[2];
+    int out_ffd;
+    int call_count;
+    char tag[16];
+    char *call_count_str;
+    char *store_dir;
+    char *record;
+    size_t record_len;
+    flb_ctx_t *ctx;
+
+    store_dir = create_test_store_directory("/flb-gcs-test-unify-size-XXXXXX");
+    TEST_CHECK(store_dir != NULL);
+    if (!store_dir) {
+        return;
+    }
+
+    record = build_large_record(600 * 1024, &record_len);
+    TEST_CHECK(record != NULL);
+    if (!record) {
+        flb_free(store_dir);
+        return;
+    }
+
+    setenv("FLB_GCS_PLUGIN_UNDER_TEST", "true", 1);
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+
+    ctx = flb_create();
+    for (i = 0; i < 2; i++) {
+        snprintf(tag, sizeof(tag), "test.%d", i);
+        in_ffd[i] = flb_input(ctx, (char *) "lib", NULL);
+        TEST_CHECK(in_ffd[i] >= 0);
+        flb_input_set(ctx, in_ffd[i], "tag", tag, NULL);
+    }
+
+    out_ffd = flb_output(ctx, (char *) "gcs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+    flb_output_set(ctx, out_ffd, "bucket", "fluent", NULL);
+    flb_output_set(ctx, out_ffd, "google_service_credentials", SERVICE_CREDENTIALS, NULL);
+    flb_output_set(ctx, out_ffd, "store_dir", store_dir, NULL);
+    flb_output_set(ctx, out_ffd, "upload_timeout", "10m", NULL);
+    flb_output_set(ctx, out_ffd, "total_file_size", "1M", NULL);
+    flb_output_set(ctx, out_ffd, "unify_tag", "true", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        flb_destroy(ctx);
+        unsetenv("FLB_GCS_PLUGIN_UNDER_TEST");
+        flb_free(record);
+        flb_free(store_dir);
+        return;
+    }
+
+    /* records from different tags land in the same unified buffer file */
+    flb_lib_push(ctx, in_ffd[0], record, (int) record_len);
+    sleep(2);
+    flb_lib_push(ctx, in_ffd[1], record, (int) record_len);
+    sleep(3);
+
+    call_count_str = getenv("TEST_GCS_UploadObject_CALL_COUNT");
+    call_count = call_count_str ? atoi(call_count_str) : 0;
+    TEST_CHECK_(call_count == 1,
+                "Expected 1 upload after the unified file reached "
+                "total_file_size, got %d", call_count);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    unsetenv("FLB_GCS_PLUGIN_UNDER_TEST");
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+    unsetenv("TEST_GCS_LAST_URI");
+    unsetenv("TEST_GCS_LAST_BODY_GZIP");
+    flb_free(record);
+    flb_free(store_dir);
+}
+
 TEST_LIST = {
     {"jwt_signing", flb_test_gcs_jwt_signing},
     {"net_settings_applied_to_upstream", flb_test_gcs_net_settings_applied_to_upstream},
@@ -1354,6 +1527,8 @@ TEST_LIST = {
     {"rejects_total_file_size_below_minimum",
      flb_test_gcs_rejects_total_file_size_below_minimum},
     {"workers_upload_all_tags", flb_test_gcs_workers_upload_all_tags},
+    {"recovers_backlog_on_restart", flb_test_gcs_recovers_backlog_on_restart},
+    {"total_file_size_with_unify_tag", flb_test_gcs_total_file_size_with_unify_tag},
     {"uri_encode_object_name", flb_test_gcs_uri_encode_object_name},
     {"upload_success", flb_test_gcs_upload_success},
 #ifdef FLB_HAVE_ARROW_PARQUET

--- a/tests/runtime/out_gcs.c
+++ b/tests/runtime/out_gcs.c
@@ -737,6 +737,7 @@ void flb_test_gcs_upload_error(void)
 
     unsetenv("FLB_GCS_PLUGIN_UNDER_TEST");
     unsetenv("TEST_GCS_UPLOAD_ERROR");
+    unsetenv("TEST_GCS_CONSTRUCT_REQUEST_BUFFER_ERROR");
     unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
     unsetenv("TEST_GCS_LAST_URI");
     unsetenv("TEST_GCS_LAST_BODY_GZIP");
@@ -1235,6 +1236,248 @@ void flb_test_gcs_total_file_size_triggers_upload(void)
     flb_free(store_dir);
 }
 
+/* Each serialized JSON line contains the message plus its JSON wrapper. */
+static void check_total_file_size_boundary(size_t file_size, int record_count)
+{
+    int ret;
+    int i;
+    int in_ffd;
+    int out_ffd;
+    int call_count;
+    char *call_count_str;
+    char *store_dir;
+    char *record;
+    size_t record_len;
+    size_t wrapper_size;
+    flb_ctx_t *ctx;
+
+    store_dir = create_test_store_directory("/flb-gcs-test-size-boundary-XXXXXX");
+    if (!TEST_CHECK(store_dir != NULL)) {
+        return;
+    }
+
+    wrapper_size = sizeof("{\"message\":\"\"}\n") - 1;
+    record = build_large_record(file_size / record_count - wrapper_size, &record_len);
+    if (!TEST_CHECK(record != NULL)) {
+        flb_free(store_dir);
+        return;
+    }
+
+    setenv("FLB_GCS_PLUGIN_UNDER_TEST", "true", 1);
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+
+    ctx = flb_create();
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "gcs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "*",
+                   "bucket", "fluent",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   "store_dir", store_dir,
+                   "upload_timeout", "10m",
+                   "total_file_size", "1M", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    if (ret == 0) {
+        for (i = 0; i < record_count; i++) {
+            ret = flb_lib_push(ctx, in_ffd, record, (int) record_len);
+            TEST_CHECK(ret == (int) record_len);
+            /* Separate flushes exercise appending to an existing file. */
+            sleep(3);
+        }
+        flb_stop(ctx);
+    }
+    flb_destroy(ctx);
+
+    /* Read the mock result after workers stop, without racing their writes. */
+    call_count_str = getenv("TEST_GCS_UploadObject_CALL_COUNT");
+    call_count = call_count_str ? atoi(call_count_str) : 0;
+    TEST_CHECK_(call_count == 1,
+                "Expected one size-triggered upload for %zu bytes in %d records, got %d",
+                file_size, record_count, call_count);
+
+    unsetenv("FLB_GCS_PLUGIN_UNDER_TEST");
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+    unsetenv("TEST_GCS_LAST_URI");
+    unsetenv("TEST_GCS_LAST_BODY_GZIP");
+    flb_free(record);
+    flb_free(store_dir);
+}
+
+void flb_test_gcs_total_file_size_exact_first_payload(void)
+{
+    check_total_file_size_boundary(1000000, 1);
+}
+
+void flb_test_gcs_total_file_size_oversized_first_payload(void)
+{
+    check_total_file_size_boundary(1200000, 1);
+}
+
+void flb_test_gcs_total_file_size_exact_append(void)
+{
+    check_total_file_size_boundary(1000000, 2);
+}
+
+/* Check size-triggered files alongside an older buffered or failed file. */
+static void check_total_file_size_queue(int preserve_ordering, int fail_upload, int fail_read)
+{
+    int ret;
+    int i;
+    int in_ffd[2];
+    int out_ffd;
+    int call_count;
+    char *call_count_str;
+    char *store_dir;
+    char *record[2];
+    size_t record_len[2];
+    size_t wrapper_size;
+    struct flb_output_instance *out_ins;
+    struct flb_gcs *gcs_ctx;
+    struct upload_queue *entry;
+    struct mk_list *head;
+    flb_ctx_t *ctx;
+
+    store_dir = create_test_store_directory("/flb-gcs-test-size-queue-XXXXXX");
+    if (!TEST_CHECK(store_dir != NULL)) {
+        return;
+    }
+    wrapper_size = sizeof("{\"message\":\"\"}\n") - 1;
+    record[0] = build_large_record((fail_upload ? 1000000 : 500000) - wrapper_size,
+                                   &record_len[0]);
+    record[1] = build_large_record((fail_upload ? 500000 : 1000000) - wrapper_size,
+                                   &record_len[1]);
+    if (!TEST_CHECK(record[0] != NULL && record[1] != NULL)) {
+        flb_free(record[0]);
+        flb_free(record[1]);
+        flb_free(store_dir);
+        return;
+    }
+    setenv("FLB_GCS_PLUGIN_UNDER_TEST", "true", 1);
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+    if (fail_upload) {
+        setenv("TEST_GCS_UPLOAD_ERROR", "true", 1);
+    }
+
+    ctx = flb_create();
+    for (i = 0; i < 2; i++) {
+        in_ffd[i] = flb_input(ctx, (char *) "lib", NULL);
+        TEST_CHECK(in_ffd[i] >= 0);
+        flb_input_set(ctx, in_ffd[i], "tag", fail_upload || i == 0 ? "first" : "second", NULL);
+    }
+    out_ffd = flb_output(ctx, (char *) "gcs", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "*",
+                   "bucket", "fluent",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   "store_dir", store_dir,
+                   "upload_timeout", "10m",
+                   "total_file_size", "1M",
+                   "preserve_data_ordering", preserve_ordering ? "true" : "false", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    if (ret == 0) {
+        for (i = 0; i < 2; i++) {
+            ret = flb_lib_push(ctx, in_ffd[i], record[i], (int) record_len[i]);
+            TEST_CHECK(ret == (int) record_len[i]);
+            sleep(3);
+            if (fail_read && i == 0) {
+                out_ins = flb_output_get_instance(ctx->config, out_ffd);
+                gcs_ctx = out_ins->context;
+                pthread_mutex_lock(&gcs_ctx->upload_lock);
+                if (TEST_CHECK(mk_list_size(&gcs_ctx->upload_queue) == 1)) {
+                    entry = mk_list_entry(gcs_ctx->upload_queue.next, struct upload_queue, _head);
+                    setenv("TEST_GCS_CONSTRUCT_REQUEST_BUFFER_ERROR", "true", 1);
+                    entry->upload_time = 0;
+                    gcs_store_file_seal(entry->upload_file);
+                }
+                pthread_mutex_unlock(&gcs_ctx->upload_lock);
+            }
+        }
+
+        out_ins = flb_output_get_instance(ctx->config, out_ffd);
+        gcs_ctx = out_ins->context;
+        pthread_mutex_lock(&gcs_ctx->upload_lock);
+        if (fail_upload) {
+            TEST_CHECK(mk_list_size(&gcs_ctx->upload_queue) == 2);
+            mk_list_foreach(head, &gcs_ctx->upload_queue) {
+                entry = mk_list_entry(head, struct upload_queue, _head);
+                if (head == gcs_ctx->upload_queue.next) {
+                    TEST_CHECK(entry->upload_file->sealed == FLB_TRUE);
+                    TEST_CHECK(entry->upload_file->size == 1000000);
+                    TEST_CHECK(entry->retry_counter > 0);
+                }
+                else {
+                    TEST_CHECK(entry->upload_file->sealed == FLB_FALSE);
+                    TEST_CHECK(entry->upload_file->size == 500000);
+                }
+            }
+        }
+        else {
+            TEST_CHECK(mk_list_size(&gcs_ctx->upload_queue) == (preserve_ordering ? 2 : 1));
+        }
+        if (fail_read) {
+            mk_list_foreach(head, &gcs_ctx->upload_queue) {
+                entry = mk_list_entry(head, struct upload_queue, _head);
+                if (head == gcs_ctx->upload_queue.next) {
+                    TEST_CHECK(entry->retry_counter > 0);
+                }
+                else {
+                    TEST_CHECK(entry->retry_counter == 0);
+                }
+            }
+        }
+        pthread_mutex_unlock(&gcs_ctx->upload_lock);
+        flb_stop(ctx);
+    }
+    flb_destroy(ctx);
+
+    call_count_str = getenv("TEST_GCS_UploadObject_CALL_COUNT");
+    call_count = call_count_str ? atoi(call_count_str) : 0;
+    if (fail_upload) {
+        TEST_CHECK(call_count > 0);
+    }
+    else {
+        TEST_CHECK(call_count == (preserve_ordering ? 0 : 1));
+    }
+
+    unsetenv("FLB_GCS_PLUGIN_UNDER_TEST");
+    unsetenv("TEST_GCS_UPLOAD_ERROR");
+    unsetenv("TEST_GCS_CONSTRUCT_REQUEST_BUFFER_ERROR");
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+    unsetenv("TEST_GCS_LAST_URI");
+    unsetenv("TEST_GCS_LAST_BODY_GZIP");
+    flb_free(record[0]);
+    flb_free(record[1]);
+    flb_free(store_dir);
+}
+
+void flb_test_gcs_total_file_size_preserves_ordering(void)
+{
+    check_total_file_size_queue(FLB_TRUE, FLB_FALSE, FLB_FALSE);
+}
+
+void flb_test_gcs_total_file_size_without_ordering(void)
+{
+    check_total_file_size_queue(FLB_FALSE, FLB_FALSE, FLB_FALSE);
+}
+
+void flb_test_gcs_total_file_size_failed_upload_stays_sealed(void)
+{
+    check_total_file_size_queue(FLB_TRUE, FLB_TRUE, FLB_FALSE);
+}
+
+void flb_test_gcs_total_file_size_ordered_read_failure(void)
+{
+    check_total_file_size_queue(FLB_TRUE, FLB_FALSE, FLB_TRUE);
+}
+
 void flb_test_gcs_rejects_total_file_size_below_minimum(void)
 {
     int ret;
@@ -1350,7 +1593,7 @@ void flb_test_gcs_workers_upload_all_tags(void)
  * shortly after startup (the recovery path runs from init and from the
  * upload timer, both outside of any flush coroutine).
  */
-void flb_test_gcs_recovers_backlog_on_restart(void)
+static void check_backlog_recovery(int fail_upload)
 {
     int ret;
     int in_ffd;
@@ -1359,6 +1602,9 @@ void flb_test_gcs_recovers_backlog_on_restart(void)
     char *call_count_str;
     char *store_dir;
     flb_ctx_t *ctx;
+    struct flb_output_instance *out_ins;
+    struct flb_gcs *gcs_ctx;
+    struct upload_queue *entry;
 
     store_dir = create_test_store_directory("/flb-gcs-test-backlog-XXXXXX");
     TEST_CHECK(store_dir != NULL);
@@ -1403,6 +1649,9 @@ void flb_test_gcs_recovers_backlog_on_restart(void)
                 "Expected no upload before shutdown, got %d", call_count);
 
     /* second instance on the same store_dir: backlog must be uploaded */
+    if (fail_upload) {
+        setenv("TEST_GCS_UPLOAD_ERROR", "true", 1);
+    }
     ctx = flb_create();
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -1425,15 +1674,37 @@ void flb_test_gcs_recovers_backlog_on_restart(void)
         TEST_CHECK_(call_count == 1,
                     "Expected recovered backlog to be uploaded once, got %d",
                     call_count);
+        if (fail_upload) {
+            out_ins = flb_output_get_instance(ctx->config, out_ffd);
+            gcs_ctx = out_ins->context;
+            pthread_mutex_lock(&gcs_ctx->upload_lock);
+            if (TEST_CHECK(mk_list_size(&gcs_ctx->upload_queue) == 1)) {
+                entry = mk_list_entry(gcs_ctx->upload_queue.next, struct upload_queue, _head);
+                TEST_CHECK(entry->upload_file->sealed == FLB_TRUE);
+                TEST_CHECK(gcs_store_file_get(gcs_ctx, "test", 4) == NULL);
+            }
+            pthread_mutex_unlock(&gcs_ctx->upload_lock);
+        }
         flb_stop(ctx);
     }
     flb_destroy(ctx);
 
     unsetenv("FLB_GCS_PLUGIN_UNDER_TEST");
+    unsetenv("TEST_GCS_UPLOAD_ERROR");
     unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
     unsetenv("TEST_GCS_LAST_URI");
     unsetenv("TEST_GCS_LAST_BODY_GZIP");
     flb_free(store_dir);
+}
+
+void flb_test_gcs_recovers_backlog_on_restart(void)
+{
+    check_backlog_recovery(FLB_FALSE);
+}
+
+void flb_test_gcs_recovered_upload_failure_stays_sealed(void)
+{
+    check_backlog_recovery(FLB_TRUE);
 }
 
 /* total_file_size must also apply to the shared file used by unify_tag */
@@ -1600,12 +1871,21 @@ TEST_LIST = {
     {"timer_upload_without_ordering_uses_sync_upstream",
      flb_test_gcs_timer_upload_without_ordering_uses_sync_upstream},
     {"total_file_size_triggers_upload", flb_test_gcs_total_file_size_triggers_upload},
+    {"total_file_size_exact_first_payload", flb_test_gcs_total_file_size_exact_first_payload},
+    {"total_file_size_oversized_first_payload", flb_test_gcs_total_file_size_oversized_first_payload},
+    {"total_file_size_exact_append", flb_test_gcs_total_file_size_exact_append},
+    {"total_file_size_ordered_read_failure", flb_test_gcs_total_file_size_ordered_read_failure},
+    {"total_file_size_preserves_ordering", flb_test_gcs_total_file_size_preserves_ordering},
+    {"total_file_size_without_ordering", flb_test_gcs_total_file_size_without_ordering},
+    {"total_file_size_failed_upload_stays_sealed",
+     flb_test_gcs_total_file_size_failed_upload_stays_sealed},
     {"total_file_size_zero_disables_size_trigger",
      flb_test_gcs_total_file_size_zero_disables_size_trigger},
     {"rejects_total_file_size_below_minimum",
      flb_test_gcs_rejects_total_file_size_below_minimum},
     {"workers_upload_all_tags", flb_test_gcs_workers_upload_all_tags},
     {"recovers_backlog_on_restart", flb_test_gcs_recovers_backlog_on_restart},
+    {"recovered_upload_failure_stays_sealed", flb_test_gcs_recovered_upload_failure_stays_sealed},
     {"total_file_size_with_unify_tag", flb_test_gcs_total_file_size_with_unify_tag},
     {"uri_encode_object_name", flb_test_gcs_uri_encode_object_name},
     {"upload_success", flb_test_gcs_upload_success},

--- a/tests/runtime/out_gcs.c
+++ b/tests/runtime/out_gcs.c
@@ -995,8 +995,70 @@ void flb_test_gcs_unify_tag_disabled_by_default(void)
     flb_free(store_dir);
 }
 
+void flb_test_gcs_net_settings_applied_to_upstream(void)
+{
+    int ret;
+    int in_ffd;
+    int out_ffd;
+    char *store_dir;
+    flb_ctx_t *ctx;
+    struct flb_gcs *gcs_ctx;
+    struct flb_output_instance *out_ins;
+
+    store_dir = create_test_store_directory("/flb-gcs-test-net-XXXXXX");
+    TEST_CHECK(store_dir != NULL);
+    if (!store_dir) {
+        return;
+    }
+
+    ctx = flb_create();
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "gcs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+    flb_output_set(ctx, out_ffd, "bucket", "fluent", NULL);
+    flb_output_set(ctx, out_ffd, "google_service_credentials", SERVICE_CREDENTIALS, NULL);
+    flb_output_set(ctx, out_ffd, "store_dir", store_dir, NULL);
+    flb_output_set(ctx, out_ffd, "net.connect_timeout", "7", NULL);
+    flb_output_set(ctx, out_ffd, "net.keepalive_idle_timeout", "17", NULL);
+    flb_output_set(ctx, out_ffd, "net.keepalive_max_recycle", "5", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        flb_destroy(ctx);
+        flb_free(store_dir);
+        return;
+    }
+
+    out_ins = flb_output_get_instance(ctx->config, out_ffd);
+    TEST_CHECK(out_ins != NULL);
+    gcs_ctx = out_ins ? out_ins->context : NULL;
+    TEST_CHECK(gcs_ctx != NULL);
+
+    if (gcs_ctx && gcs_ctx->u) {
+        TEST_CHECK_(gcs_ctx->u->base.net.connect_timeout == 7,
+                    "Expected net.connect_timeout=7 on upstream, got %d",
+                    gcs_ctx->u->base.net.connect_timeout);
+        TEST_CHECK_(gcs_ctx->u->base.net.keepalive_idle_timeout == 17,
+                    "Expected net.keepalive_idle_timeout=17 on upstream, got %d",
+                    gcs_ctx->u->base.net.keepalive_idle_timeout);
+        TEST_CHECK_(gcs_ctx->u->base.net.keepalive_max_recycle == 5,
+                    "Expected net.keepalive_max_recycle=5 on upstream, got %d",
+                    gcs_ctx->u->base.net.keepalive_max_recycle);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+    flb_free(store_dir);
+}
+
 TEST_LIST = {
     {"jwt_signing", flb_test_gcs_jwt_signing},
+    {"net_settings_applied_to_upstream", flb_test_gcs_net_settings_applied_to_upstream},
     {"uri_encode_object_name", flb_test_gcs_uri_encode_object_name},
     {"upload_success", flb_test_gcs_upload_success},
 #ifdef FLB_HAVE_ARROW_PARQUET

--- a/tests/runtime/out_gcs.c
+++ b/tests/runtime/out_gcs.c
@@ -1518,12 +1518,90 @@ void flb_test_gcs_total_file_size_with_unify_tag(void)
     flb_free(store_dir);
 }
 
+/* total_file_size 0 disables the size trigger: only upload_timeout applies */
+void flb_test_gcs_total_file_size_zero_disables_size_trigger(void)
+{
+    int ret;
+    int in_ffd;
+    int out_ffd;
+    int call_count;
+    char *call_count_str;
+    char *store_dir;
+    char *record;
+    size_t record_len;
+    flb_ctx_t *ctx;
+
+    store_dir = create_test_store_directory("/flb-gcs-test-size-off-XXXXXX");
+    TEST_CHECK(store_dir != NULL);
+    if (!store_dir) {
+        return;
+    }
+
+    record = build_large_record(600 * 1024, &record_len);
+    TEST_CHECK(record != NULL);
+    if (!record) {
+        flb_free(store_dir);
+        return;
+    }
+
+    setenv("FLB_GCS_PLUGIN_UNDER_TEST", "true", 1);
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+
+    ctx = flb_create();
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "gcs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+    flb_output_set(ctx, out_ffd, "bucket", "fluent", NULL);
+    flb_output_set(ctx, out_ffd, "google_service_credentials", SERVICE_CREDENTIALS, NULL);
+    flb_output_set(ctx, out_ffd, "store_dir", store_dir, NULL);
+    flb_output_set(ctx, out_ffd, "upload_timeout", "10m", NULL);
+    flb_output_set(ctx, out_ffd, "total_file_size", "0", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK_(ret == 0, "Expected total_file_size=0 to be accepted");
+    if (ret != 0) {
+        flb_destroy(ctx);
+        unsetenv("FLB_GCS_PLUGIN_UNDER_TEST");
+        flb_free(record);
+        flb_free(store_dir);
+        return;
+    }
+
+    /* more than 1M of buffered data must NOT trigger an upload */
+    flb_lib_push(ctx, in_ffd, record, (int) record_len);
+    sleep(2);
+    flb_lib_push(ctx, in_ffd, record, (int) record_len);
+    sleep(3);
+
+    call_count_str = getenv("TEST_GCS_UploadObject_CALL_COUNT");
+    call_count = call_count_str ? atoi(call_count_str) : 0;
+    TEST_CHECK_(call_count == 0,
+                "Expected no size-triggered upload with total_file_size=0, "
+                "got %d", call_count);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    unsetenv("FLB_GCS_PLUGIN_UNDER_TEST");
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+    unsetenv("TEST_GCS_LAST_URI");
+    unsetenv("TEST_GCS_LAST_BODY_GZIP");
+    flb_free(record);
+    flb_free(store_dir);
+}
+
 TEST_LIST = {
     {"jwt_signing", flb_test_gcs_jwt_signing},
     {"net_settings_applied_to_upstream", flb_test_gcs_net_settings_applied_to_upstream},
     {"timer_upload_without_ordering_uses_sync_upstream",
      flb_test_gcs_timer_upload_without_ordering_uses_sync_upstream},
     {"total_file_size_triggers_upload", flb_test_gcs_total_file_size_triggers_upload},
+    {"total_file_size_zero_disables_size_trigger",
+     flb_test_gcs_total_file_size_zero_disables_size_trigger},
     {"rejects_total_file_size_below_minimum",
      flb_test_gcs_rejects_total_file_size_below_minimum},
     {"workers_upload_all_tags", flb_test_gcs_workers_upload_all_tags},

--- a/tests/runtime/out_gcs.c
+++ b/tests/runtime/out_gcs.c
@@ -1134,11 +1134,151 @@ void flb_test_gcs_timer_upload_without_ordering_uses_sync_upstream(void)
     flb_free(store_dir);
 }
 
+/* Build a single ~size-byte JSON record for in_lib */
+static char *build_large_record(size_t size, size_t *out_len)
+{
+    char *buf;
+    size_t prefix_len;
+    const char *prefix = "[0, {\"message\": \"";
+    const char *suffix = "\"}]";
+
+    prefix_len = strlen(prefix);
+    buf = flb_malloc(size + prefix_len + strlen(suffix) + 1);
+    if (!buf) {
+        return NULL;
+    }
+    memcpy(buf, prefix, prefix_len);
+    memset(buf + prefix_len, 'a', size);
+    memcpy(buf + prefix_len + size, suffix, strlen(suffix) + 1);
+    *out_len = prefix_len + size + strlen(suffix);
+    return buf;
+}
+
+void flb_test_gcs_total_file_size_triggers_upload(void)
+{
+    int ret;
+    int in_ffd;
+    int out_ffd;
+    int call_count;
+    char *call_count_str;
+    char *store_dir;
+    char *record;
+    size_t record_len;
+    flb_ctx_t *ctx;
+
+    store_dir = create_test_store_directory("/flb-gcs-test-total-size-XXXXXX");
+    TEST_CHECK(store_dir != NULL);
+    if (!store_dir) {
+        return;
+    }
+
+    record = build_large_record(600 * 1024, &record_len);
+    TEST_CHECK(record != NULL);
+    if (!record) {
+        flb_free(store_dir);
+        return;
+    }
+
+    setenv("FLB_GCS_PLUGIN_UNDER_TEST", "true", 1);
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+
+    ctx = flb_create();
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "gcs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+    flb_output_set(ctx, out_ffd, "bucket", "fluent", NULL);
+    flb_output_set(ctx, out_ffd, "google_service_credentials", SERVICE_CREDENTIALS, NULL);
+    flb_output_set(ctx, out_ffd, "store_dir", store_dir, NULL);
+    /* long timeout: only total_file_size can trigger an upload in this test */
+    flb_output_set(ctx, out_ffd, "upload_timeout", "10m", NULL);
+    flb_output_set(ctx, out_ffd, "total_file_size", "1M", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        flb_destroy(ctx);
+        unsetenv("FLB_GCS_PLUGIN_UNDER_TEST");
+        flb_free(record);
+        flb_free(store_dir);
+        return;
+    }
+
+    /* first record (~600KB) is buffered, no upload yet */
+    flb_lib_push(ctx, in_ffd, record, (int) record_len);
+    sleep(3);
+    call_count_str = getenv("TEST_GCS_UploadObject_CALL_COUNT");
+    call_count = call_count_str ? atoi(call_count_str) : 0;
+    TEST_CHECK_(call_count == 0,
+                "Expected no upload below total_file_size, got %d", call_count);
+
+    /* second record would exceed 1M: the buffered file must be uploaded */
+    flb_lib_push(ctx, in_ffd, record, (int) record_len);
+    sleep(3);
+    call_count_str = getenv("TEST_GCS_UploadObject_CALL_COUNT");
+    call_count = call_count_str ? atoi(call_count_str) : 0;
+    TEST_CHECK_(call_count == 1,
+                "Expected 1 upload after reaching total_file_size, got %d",
+                call_count);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    unsetenv("FLB_GCS_PLUGIN_UNDER_TEST");
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+    unsetenv("TEST_GCS_LAST_URI");
+    unsetenv("TEST_GCS_LAST_BODY_GZIP");
+    flb_free(record);
+    flb_free(store_dir);
+}
+
+void flb_test_gcs_rejects_total_file_size_below_minimum(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    char *store_dir;
+
+    store_dir = create_test_store_directory("/flb-gcs-test-small-total-size-XXXXXX");
+    TEST_CHECK(store_dir != NULL);
+    if (!store_dir) {
+        return;
+    }
+
+    ctx = flb_create();
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "gcs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+    flb_output_set(ctx, out_ffd, "bucket", "fluent", NULL);
+    flb_output_set(ctx, out_ffd, "google_service_credentials", SERVICE_CREDENTIALS, NULL);
+    flb_output_set(ctx, out_ffd, "store_dir", store_dir, NULL);
+    flb_output_set(ctx, out_ffd, "total_file_size", "512K", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK_(ret != 0, "Expected total_file_size below 1M to be rejected");
+    if (ret == 0) {
+        flb_stop(ctx);
+    }
+    flb_destroy(ctx);
+    flb_free(store_dir);
+}
+
 TEST_LIST = {
     {"jwt_signing", flb_test_gcs_jwt_signing},
     {"net_settings_applied_to_upstream", flb_test_gcs_net_settings_applied_to_upstream},
     {"timer_upload_without_ordering_uses_sync_upstream",
      flb_test_gcs_timer_upload_without_ordering_uses_sync_upstream},
+    {"total_file_size_triggers_upload", flb_test_gcs_total_file_size_triggers_upload},
+    {"rejects_total_file_size_below_minimum",
+     flb_test_gcs_rejects_total_file_size_below_minimum},
     {"uri_encode_object_name", flb_test_gcs_uri_encode_object_name},
     {"upload_success", flb_test_gcs_upload_success},
 #ifdef FLB_HAVE_ARROW_PARQUET

--- a/tests/runtime/out_gcs.c
+++ b/tests/runtime/out_gcs.c
@@ -1056,9 +1056,89 @@ void flb_test_gcs_net_settings_applied_to_upstream(void)
     flb_free(store_dir);
 }
 
+/*
+ * The upload timer callback runs outside of any coroutine. If the upstream
+ * were left in async mode, the first network write from the timer would
+ * try to yield a NULL coroutine and crash. The plugin must therefore keep
+ * the upstream in sync mode and still deliver timer-driven uploads when
+ * preserve_data_ordering is disabled.
+ */
+void flb_test_gcs_timer_upload_without_ordering_uses_sync_upstream(void)
+{
+    int ret;
+    int in_ffd;
+    int out_ffd;
+    int call_count;
+    char *call_count_str;
+    char *store_dir;
+    flb_ctx_t *ctx;
+    struct flb_gcs *gcs_ctx;
+    struct flb_output_instance *out_ins;
+
+    store_dir = create_test_store_directory("/flb-gcs-test-unordered-XXXXXX");
+    TEST_CHECK(store_dir != NULL);
+    if (!store_dir) {
+        return;
+    }
+
+    setenv("FLB_GCS_PLUGIN_UNDER_TEST", "true", 1);
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+
+    ctx = flb_create();
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "gcs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+    flb_output_set(ctx, out_ffd, "bucket", "fluent", NULL);
+    flb_output_set(ctx, out_ffd, "google_service_credentials", SERVICE_CREDENTIALS, NULL);
+    flb_output_set(ctx, out_ffd, "store_dir", store_dir, NULL);
+    flb_output_set(ctx, out_ffd, "upload_timeout", "3s", NULL);
+    flb_output_set(ctx, out_ffd, "preserve_data_ordering", "false", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        flb_destroy(ctx);
+        unsetenv("FLB_GCS_PLUGIN_UNDER_TEST");
+        flb_free(store_dir);
+        return;
+    }
+
+    out_ins = flb_output_get_instance(ctx->config, out_ffd);
+    TEST_CHECK(out_ins != NULL);
+    gcs_ctx = out_ins ? out_ins->context : NULL;
+    TEST_CHECK(gcs_ctx != NULL);
+    if (gcs_ctx && gcs_ctx->u) {
+        TEST_CHECK_(flb_stream_is_async(&gcs_ctx->u->base) == FLB_FALSE,
+                    "Expected the GCS upstream to run in sync mode");
+    }
+
+    flb_lib_push(ctx, in_ffd, (char *) JSON_TD, (int) sizeof(JSON_TD) - 1);
+    sleep(6);
+
+    call_count_str = getenv("TEST_GCS_UploadObject_CALL_COUNT");
+    call_count = call_count_str ? atoi(call_count_str) : 0;
+    TEST_CHECK_(call_count == 1,
+                "Expected 1 timer-driven UploadObject call, got %d", call_count);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    unsetenv("FLB_GCS_PLUGIN_UNDER_TEST");
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+    unsetenv("TEST_GCS_LAST_URI");
+    unsetenv("TEST_GCS_LAST_BODY_GZIP");
+    flb_free(store_dir);
+}
+
 TEST_LIST = {
     {"jwt_signing", flb_test_gcs_jwt_signing},
     {"net_settings_applied_to_upstream", flb_test_gcs_net_settings_applied_to_upstream},
+    {"timer_upload_without_ordering_uses_sync_upstream",
+     flb_test_gcs_timer_upload_without_ordering_uses_sync_upstream},
     {"uri_encode_object_name", flb_test_gcs_uri_encode_object_name},
     {"upload_success", flb_test_gcs_upload_success},
 #ifdef FLB_HAVE_ARROW_PARQUET

--- a/tests/runtime/out_gcs.c
+++ b/tests/runtime/out_gcs.c
@@ -1271,6 +1271,80 @@ void flb_test_gcs_rejects_total_file_size_below_minimum(void)
     flb_free(store_dir);
 }
 
+/*
+ * Multiple output workers flush concurrently and share the upload queue,
+ * the local file store and the sequence index. Every tag must still be
+ * uploaded exactly once and the process must not crash or corrupt state.
+ */
+void flb_test_gcs_workers_upload_all_tags(void)
+{
+    int i;
+    int ret;
+    int in_ffd[4];
+    int out_ffd;
+    int call_count;
+    char tag[16];
+    char *call_count_str;
+    char *store_dir;
+    flb_ctx_t *ctx;
+
+    store_dir = create_test_store_directory("/flb-gcs-test-workers-XXXXXX");
+    TEST_CHECK(store_dir != NULL);
+    if (!store_dir) {
+        return;
+    }
+
+    setenv("FLB_GCS_PLUGIN_UNDER_TEST", "true", 1);
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+
+    ctx = flb_create();
+    for (i = 0; i < 4; i++) {
+        snprintf(tag, sizeof(tag), "test.%d", i);
+        in_ffd[i] = flb_input(ctx, (char *) "lib", NULL);
+        TEST_CHECK(in_ffd[i] >= 0);
+        flb_input_set(ctx, in_ffd[i], "tag", tag, NULL);
+    }
+
+    out_ffd = flb_output(ctx, (char *) "gcs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+    flb_output_set(ctx, out_ffd, "bucket", "fluent", NULL);
+    flb_output_set(ctx, out_ffd, "google_service_credentials", SERVICE_CREDENTIALS, NULL);
+    flb_output_set(ctx, out_ffd, "store_dir", store_dir, NULL);
+    flb_output_set(ctx, out_ffd, "upload_timeout", "3s", NULL);
+    flb_output_set(ctx, out_ffd, "preserve_data_ordering", "true", NULL);
+    flb_output_set(ctx, out_ffd, "gcs_key_format", "logs/$TAG/$INDEX", NULL);
+    flb_output_set(ctx, out_ffd, "workers", "4", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        flb_destroy(ctx);
+        unsetenv("FLB_GCS_PLUGIN_UNDER_TEST");
+        flb_free(store_dir);
+        return;
+    }
+
+    for (i = 0; i < 4; i++) {
+        flb_lib_push(ctx, in_ffd[i], (char *) JSON_TD, (int) sizeof(JSON_TD) - 1);
+    }
+    sleep(6);
+
+    call_count_str = getenv("TEST_GCS_UploadObject_CALL_COUNT");
+    call_count = call_count_str ? atoi(call_count_str) : 0;
+    TEST_CHECK_(call_count == 4,
+                "Expected 4 UploadObject calls (one per tag), got %d", call_count);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    unsetenv("FLB_GCS_PLUGIN_UNDER_TEST");
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+    unsetenv("TEST_GCS_LAST_URI");
+    unsetenv("TEST_GCS_LAST_BODY_GZIP");
+    flb_free(store_dir);
+}
+
 TEST_LIST = {
     {"jwt_signing", flb_test_gcs_jwt_signing},
     {"net_settings_applied_to_upstream", flb_test_gcs_net_settings_applied_to_upstream},
@@ -1279,6 +1353,7 @@ TEST_LIST = {
     {"total_file_size_triggers_upload", flb_test_gcs_total_file_size_triggers_upload},
     {"rejects_total_file_size_below_minimum",
      flb_test_gcs_rejects_total_file_size_below_minimum},
+    {"workers_upload_all_tags", flb_test_gcs_workers_upload_all_tags},
     {"uri_encode_object_name", flb_test_gcs_uri_encode_object_name},
     {"upload_success", flb_test_gcs_upload_success},
 #ifdef FLB_HAVE_ARROW_PARQUET


### PR DESCRIPTION
This follows up on #12263 with fixes for problems found while running the GCS output in production, plus a new option to upload files based on size.

- **Network settings were ignored.** The plugin accepted `net.*` options but did not apply them to the GCS upload connection. It now applies those settings, including connection timeouts and keepalive options.
- **Uploads could crash with `preserve_data_ordering false`.** Timer uploads used a network mode that was unsafe outside a flush callback. Uploads now use synchronous I/O in both ordering modes. This also covers uploads of files recovered at startup. With `workers 0`, uploads block the main event loop, so the plugin logs a warning.
- **Multiple workers could crash or lose uploads.** Workers and the upload timer changed the same queue and buffered files at the same time. A lock now protects that shared state. Uploads run one at a time, even with multiple workers. Ordered uploads can also process several ready files per pass instead of just one; an upload failure stops the pass.

`total_file_size` adds size-based rollover. If appending a batch would put an existing file over the limit, the plugin closes that file to further writes, marks it ready for upload, and starts a new file for the batch. This also works with `unify_tag`.

The default is `100M`, the minimum nonzero value is `1M`, and `0` keeps the previous timeout-only behavior. With ordering enabled, a file marked ready by the size check still waits behind older files.

Files that reach or exceed `total_file_size` are now marked ready immediately, including an oversized first batch or an append that lands exactly on the limit. The setting is not a hard object-size cap because batches are not split. Buffer-read failures stop the queue pass and schedule a retry. Recovered files stay closed to new records after failed uploads.

**Testing**

New runtime tests cover network settings, timer uploads with ordering disabled, size-based rollover, disabling the size check, invalid sizes, four workers, restart recovery, and `unify_tag`.

The upload tests use mocked requests. They check buffering and scheduling, but do not exercise real GCS network I/O. The four-worker test checks the number of upload calls; it does not check the contents of every uploaded object.

Previous testing reported on this PR: all 25 runtime tests passed on macOS arm64 and Ubuntu 24.04 arm64. The four-worker test was also reported to fail with 31 ThreadSanitizer race reports before the fix and pass with none afterward. Those ThreadSanitizer results have not been rerun in this review.

Rechecked on macOS arm64 with the fixes in `61ca8668a`:

```sh
cmake --build build --target flb-rt-out_gcs -j8
ctest --test-dir build -R '^flb-rt-out_gcs$' --output-on-failure
leaks --atExit -- ./build/bin/flb-rt-out_gcs --no-exec
```

The build and all 33 runtime tests passed. Eight additional tests cover size boundaries, ordering, failed uploads, buffer-read failures, and failed recovery uploads. Leaks reported 0 leaks and 0 leaked bytes. There is no GCS scenario in `tests/integration`, so no Python integration test was run. Commit-prefix lint also passed for the full PR range against `master`.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Example configuration:

```ini
[SERVICE]
    flush 1

[INPUT]
    name dummy
    tag  gcs.test

[OUTPUT]
    name                       gcs
    match                      *
    bucket                     my-bucket
    total_file_size            50M
    upload_timeout             5m
    preserve_data_ordering     false
    workers                    4
    net.keepalive              on
    net.keepalive_idle_timeout 20
```

Previously reported Valgrind run (Ubuntu 24.04, 30s run of `fluent-bit` with the configuration above, 2 workers, mocked uploads, then SIGTERM):

```
==30796== HEAP SUMMARY:
==30796==     in use at exit: 0 bytes in 0 blocks
==30796==   total heap usage: 13,516 allocs, 13,516 frees, 18,331,306 bytes allocated
==30796== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

The previous test run also reported that each of the 8 new runtime tests passed under `valgrind --leak-check=full --error-exitcode=99` (in-process via acutest `--no-exec`) with 0 errors.

Debug log excerpt (2 workers flushing concurrently):

```
[debug] [gcs:gcs.0] created event channels: read=23 write=24
[ info] [output:gcs:gcs.0] worker #0 started
[ info] [output:gcs:gcs.0] worker #1 started
[debug] [output:gcs:gcs.0] task_id=0 assigned to thread #0
[debug] [output:gcs:gcs.0] task_id=0 assigned to thread #1
[ info] [output:gcs:gcs.0] thread worker #0 stopped
[ info] [output:gcs:gcs.0] thread worker #1 stopped
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [x] Documentation required for this feature

Docs PR for `total_file_size` (and notes on `net.*` support and `workers`) will follow in fluent/fluent-bit-docs.

**Backporting**
- [ ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Cloud Storage uploads when payloads reach or exceed the configured total file size.
  * Prevented failed uploads from being skipped, ensuring they are retried with backoff.
  * Preserved upload ordering and reliability during retries, read failures, and backlog recovery.
  * Ensured recovered and completed chunks are correctly queued for upload rather than receiving additional data.

* **Tests**
  * Added coverage for file-size limits, upload failures, ordering, retries, and restart recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->