### PR TITLE
in_podman_metrics: do not abort startup when the initial scrape fails

### DIFF
--- a/plugins/in_podman_metrics/podman_metrics.c
+++ b/plugins/in_podman_metrics/podman_metrics.c
@@ -485,11 +485,16 @@ static int in_metrics_init(struct flb_input_instance *in, struct flb_config *con
     if (ctx->scrape_interval >= 2 && ctx->scrape_on_start) {
         flb_plg_info(ctx->ins, "Generating podman metrics (initial scrape)");
         if (scrape_metrics(config, ctx) == -1) {
-            flb_plg_error(ctx->ins, "Could not start collector for podman metrics plugin");
-            flb_sds_destroy(ctx->config);
-            destroy_container_list(ctx);
-            flb_free(ctx);
-            return -1;
+            /*
+             * A failed initial scrape is not a reason to abort startup: the
+             * usual cause is that the podman config file does not exist yet
+             * (podman has not run, or its storage is not mounted), which is a
+             * transient condition. The interval collector retries and the same
+             * failure is only a warning there, so keep the plugin alive rather
+             * than failing init, which would take down the whole engine.
+             */
+            flb_plg_warn(ctx->ins, "Initial scrape failed, retrying in %i seconds",
+                         ctx->scrape_interval);
         }
     }
 

--- a/tests/runtime/in_podman_metrics.c
+++ b/tests/runtime/in_podman_metrics.c
@@ -57,6 +57,27 @@ int check_metric(flb_ctx_t *ctx, char *name) {
 
 }
 
+/* Whether a counter with the given name is present. check_metric() cannot
+ * express this: it returns 0 both when the counter is found and when the input
+ * exposes no counters at all. */
+int metric_exists(flb_ctx_t *ctx, char *name) {
+    struct mk_list *head;
+    struct cfl_list *inner_head;
+    struct flb_input_instance *i_ins;
+    struct cmt_counter *counter;
+
+    mk_list_foreach(head, &ctx->config->inputs) {
+        i_ins = mk_list_entry(head, struct flb_input_instance, _head);
+        cfl_list_foreach(inner_head, &i_ins->cmt->counters) {
+            counter = cfl_list_entry(inner_head, struct cmt_counter, _head);
+            if (strcmp(name, counter->opts.name) == 0) {
+                return FLB_TRUE;
+            }
+        }
+    }
+    return FLB_FALSE;
+}
+
 void do_create(flb_ctx_t *ctx, char *system, ...)
 {
     int in_ffd;
@@ -125,7 +146,15 @@ void flb_test_ipm_garbage_config() {
             "path.sysfs", DPATH_PODMAN_GARBAGE_CONFIG,
             "path.procfs", DPATH_PODMAN_GARBAGE_CONFIG,
             NULL);
-    TEST_CHECK(flb_start(ctx) != 0);
+    /*
+     * An unparsable config file must not abort startup. Podman rewrites
+     * containers.json in place, so a scrape can race with that write and read
+     * a partial file. The plugin warns and the interval collector retries, so
+     * the engine starts but exposes no container metrics.
+     */
+    TEST_CHECK(flb_start(ctx) == 0);
+    sleep(1);
+    TEST_CHECK(metric_exists(ctx, "usage_bytes") == FLB_FALSE);
     do_destroy(ctx);
 }
 
@@ -138,7 +167,13 @@ void flb_test_ipm_no_config() {
             "path.sysfs", DPATH_PODMAN_NO_CONFIG,
             "path.procfs", DPATH_PODMAN_NO_CONFIG,
             NULL);
-    TEST_CHECK(flb_start(ctx) != 0);
+    /*
+     * A missing config file must not abort startup either: podman may simply
+     * not have run on this host yet. Same contract as the garbage config case.
+     */
+    TEST_CHECK(flb_start(ctx) == 0);
+    sleep(1);
+    TEST_CHECK(metric_exists(ctx, "usage_bytes") == FLB_FALSE);
     do_destroy(ctx);
 }
 


### PR DESCRIPTION
## Summary

With `scrape_on_start` enabled, a failing initial scrape makes `in_metrics_init` return `-1`. Fluent Bit treats a failed input initialization as fatal, so the whole process exits rather than that one input being degraded.

The usual trigger is a podman config file that does not exist yet: podman has not run on the host, or its storage is not mounted. That is a transient condition, not a misconfiguration.

## Why this is inconsistent today

`collect_container_data` already reports the missing file with `flb_plg_warn`, not an error:

```c
flb_utils_read_file(ctx->config, &buffer, &read_bytes);
if (!read_bytes) {
    flb_plg_warn(ctx->ins, "Failed to open %s", ctx->config);
    return -1;
}
```

but `in_metrics_init` turns that same `-1` into a fatal init failure:

```c
if (ctx->scrape_interval >= 2 && ctx->scrape_on_start) {
    if (scrape_metrics(config, ctx) == -1) {
        ...
        return -1;
    }
}
```

The interval collector `cb_metrics_collect_runtime` hits the identical failure with no consequence beyond a logged warning. So whether the process survives depends only on whether the first scrape happened during init or one interval later. `scrape_on_start` is a timing convenience; it should not change liveness semantics.

Note an *empty* container list is already handled correctly (`[]` parses as a JSMN array with zero entries). Only an absent file trips this.

## Change

Log a warning and let the interval collector retry. A partially collected container list is discarded by `destroy_container_list` at the top of the next scrape, so no stale state survives.

## How it shows up

On an embedded image where the container storage lives on a data partition that is empty on first boot:

```
fluent-bit.service: Main process exited, code=exited, status=255/EXCEPTION
fluent-bit.service: Scheduled restart job, restart counter is at 5.
fluent-bit.service: Start request repeated too quickly.
Failed to start Fluent Bit.
```

Fluent Bit never starts, so no inputs run at all, not just podman metrics.

## Related

- #11719 (`in_podman_metrics` cgroup v2 fixes) and #11970 (`exclude_name_regex`), both still open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The metrics service now continues starting when the initial container metrics scrape fails.
  * A warning is shown, and the scrape is retried automatically after the configured interval.
  * When container configuration is missing or invalid, the service starts successfully without exposing container usage metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->