### PR TITLE
flb_processor: fix numeric condition rule values not cast to double

### DIFF
--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -824,6 +824,7 @@ static int flb_processor_unit_set_condition(struct flb_processor_unit *pu, struc
     const char *field;
     const char *operator;
     void *value = NULL;
+    double numeric_rule_value;
     int value_count;
     enum record_context_type context;
     int i;
@@ -976,12 +977,14 @@ static int flb_processor_unit_set_condition(struct flb_processor_unit *pu, struc
                         (char *)value);
         }
         else if (rule_val->type == CFL_VARIANT_INT) {
-            value = &rule_val->data.as_int64;
+            numeric_rule_value = (double) rule_val->data.as_int64;
+            value = &numeric_rule_value;
             flb_debug("[processor] condition rule value (int): %lld",
                     rule_val->data.as_int64);
         }
         else if (rule_val->type == CFL_VARIANT_UINT) {
-            value = &rule_val->data.as_uint64;
+            numeric_rule_value = (double) rule_val->data.as_uint64;
+            value = &numeric_rule_value;
             flb_debug("[processor] condition rule value (uint): %lu",
                     (unsigned long)rule_val->data.as_uint64);
         }


### PR DESCRIPTION
When a condition rule uses GT/LT/GTE/LTE with an integer variant (CFL_VARIANT_INT or CFL_VARIANT_UINT), the value pointer was typed as int64_t*/uint64_t* but rule_create read it as double* via *(double*)value, producing a garbage comparison threshold.

Fix: convert INT and UINT variants to double at the call site before passing the address to flb_condition_add_rule, so the callee always receives a proper double*.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric condition handling for integer and unsigned-integer values by ensuring they are processed consistently as floating-point numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->