### PR TITLE
out_opentelemetry: add metric age cut-off filter

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -802,6 +802,7 @@ static int process_metrics(struct flb_event_chunk *event_chunk,
     flb_sds_t buf = NULL;
     size_t diff = 0;
     size_t off = 0;
+    uint64_t expiration;
     struct cmt *cmt;
     struct opentelemetry_context *ctx = out_context;
 
@@ -809,6 +810,14 @@ static int process_metrics(struct flb_event_chunk *event_chunk,
     ctx = out_context;
     ok = CMT_DECODE_MSGPACK_SUCCESS;
     result = FLB_OK;
+
+    if (ctx->cutoff_threshold > 0) {
+        expiration = cfl_time_now() -
+                     ((uint64_t) ctx->cutoff_threshold * 1000000000ULL);
+    }
+    else {
+        expiration = 0;
+    }
 
     /* Buffer to concatenate multiple metrics contexts */
     buf = flb_sds_create_size(event_chunk->size);
@@ -825,6 +834,11 @@ static int process_metrics(struct flb_event_chunk *event_chunk,
     while ((ret = cmt_decode_msgpack_create(&cmt,
                                             (char *) event_chunk->data,
                                             event_chunk->size, &off)) == ok) {
+        /* Exclude samples older than the configured cut-off. */
+        if (expiration > 0) {
+            cmt_expire(cmt, expiration);
+        }
+
         /* append labels set by config */
         append_labels(ctx, cmt);
 
@@ -832,7 +846,7 @@ static int process_metrics(struct flb_event_chunk *event_chunk,
         encoded_chunk = cmt_encode_opentelemetry_create(cmt);
         if (encoded_chunk == NULL) {
             flb_plg_error(ctx->ins,
-                          "Error encoding context as opentelemetry");
+                          "Error encoding metrics as opentelemetry");
             result = FLB_ERROR;
             cmt_destroy(cmt);
             goto exit;
@@ -1339,6 +1353,11 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "logs_severity_number_message_key", "$SeverityNumber",
      0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_severity_number_message_key),
      "Specify a Severity Number key"
+    },
+    {
+     FLB_CONFIG_MAP_TIME, "cut_off_time", "0",
+     0, FLB_TRUE, offsetof(struct opentelemetry_context, cutoff_threshold),
+     "Specify an optional filter on metric age. Default 0s"
     },
 
 

--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -789,6 +789,23 @@ static int post_metrics_payload(struct opentelemetry_context *ctx,
     return result;
 }
 
+void otel_metrics_apply_cutoff(struct cmt *cmt, int threshold_seconds)
+{
+    uint64_t threshold_ns;
+    uint64_t now;
+    uint64_t expiration;
+
+    if (threshold_seconds <= 0) {
+        return;
+    }
+    threshold_ns = (uint64_t) threshold_seconds * 1000000000ULL;
+    now = cfl_time_now();
+    expiration = (threshold_ns < now) ? (now - threshold_ns) : 0;
+    if (expiration > 0) {
+        cmt_expire(cmt, expiration);
+    }
+}
+
 static int process_metrics(struct flb_event_chunk *event_chunk,
                            struct flb_output_flush *out1_flush,
                            struct flb_input_instance *ins, void *out_context,
@@ -802,7 +819,6 @@ static int process_metrics(struct flb_event_chunk *event_chunk,
     flb_sds_t buf = NULL;
     size_t diff = 0;
     size_t off = 0;
-    uint64_t expiration;
     struct cmt *cmt;
     struct opentelemetry_context *ctx = out_context;
 
@@ -810,14 +826,6 @@ static int process_metrics(struct flb_event_chunk *event_chunk,
     ctx = out_context;
     ok = CMT_DECODE_MSGPACK_SUCCESS;
     result = FLB_OK;
-
-    if (ctx->cutoff_threshold > 0) {
-        expiration = cfl_time_now() -
-                     ((uint64_t) ctx->cutoff_threshold * 1000000000ULL);
-    }
-    else {
-        expiration = 0;
-    }
 
     /* Buffer to concatenate multiple metrics contexts */
     buf = flb_sds_create_size(event_chunk->size);
@@ -835,9 +843,7 @@ static int process_metrics(struct flb_event_chunk *event_chunk,
                                             (char *) event_chunk->data,
                                             event_chunk->size, &off)) == ok) {
         /* Exclude samples older than the configured cut-off. */
-        if (expiration > 0) {
-            cmt_expire(cmt, expiration);
-        }
+        otel_metrics_apply_cutoff(cmt, ctx->cutoff_threshold);
 
         /* append labels set by config */
         append_labels(ctx, cmt);

--- a/plugins/out_opentelemetry/opentelemetry.h
+++ b/plugins/out_opentelemetry/opentelemetry.h
@@ -225,4 +225,6 @@ int opentelemetry_post(struct opentelemetry_context *ctx,
                        const char *tag, int tag_len,
                        const char *http_uri,
                        const char *grpc_uri);
+
+void otel_metrics_apply_cutoff(struct cmt *cmt, int threshold_seconds);
 #endif

--- a/plugins/out_opentelemetry/opentelemetry.h
+++ b/plugins/out_opentelemetry/opentelemetry.h
@@ -194,6 +194,9 @@ struct opentelemetry_context {
     /* compression: zstd */
     int compress_zstd;
 
+    /* cutoff threshold */
+    int cutoff_threshold;
+
     /* FLB/OTLP Record accessor patterns */
     struct flb_record_accessor *ra_meta_schema;
     struct flb_record_accessor *ra_meta_resource_id;

--- a/tests/internal/opentelemetry.c
+++ b/tests/internal/opentelemetry.c
@@ -43,6 +43,7 @@
 #include <ctraces/ctr_encode_opentelemetry.h>
 #include <fluent-otel-proto/fluent-otel.h>
 #include <msgpack.h>
+#include <limits.h>
 #include <string.h>
 #include <fluent-bit/flb_json.h>
 
@@ -3410,6 +3411,63 @@ void test_opentelemetry_traces_otlp_proto_roundtrip()
     ctr_destroy(trace_context);
 }
 
+/* Declaration of the cutoff helper from the out_opentelemetry plugin */
+extern void otel_metrics_apply_cutoff(struct cmt *cmt, int threshold_seconds);
+
+/*
+ * Test the metric age cut-off feature in the out_opentelemetry plugin.
+ * Calls the plugin's own flb_otel_metric_expire() — the same function
+ * used by process_metrics() — and verifies that:
+ *   1. Stale data points are dropped with a normal threshold.
+ *   2. The underflow guard (threshold_ns > now → no expire) prevents
+ *      data loss when the threshold would exceed current Unix time.
+ */
+void test_opentelemetry_metrics_cutoff()
+{
+    struct cmt       *cmt;
+    struct cmt_gauge *g;
+    uint64_t          now;
+
+    cmt_initialize();
+
+    /* --- normal cutoff: 200-second-old sample expires, 1-second-old survives --- */
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    g = cmt_gauge_create(cmt, "test", "otel", "cutoff", "cutoff test", 1,
+                         (char *[]) {"host"});
+    TEST_CHECK(g != NULL);
+
+    now = cfl_time_now();
+    cmt_gauge_set(g, now - 1000000000ULL,   1.0, 1, (char *[]) {"fresh"});
+    cmt_gauge_set(g, now - 200000000000ULL, 2.0, 1, (char *[]) {"stale"});
+
+    TEST_CHECK(cfl_list_size(&g->map->metrics) == 2);
+
+    /* plugin function: cutoff_threshold = 100 s → stale sample dropped */
+    otel_metrics_apply_cutoff(cmt, 100);
+
+    TEST_CHECK(cfl_list_size(&g->map->metrics) == 1);
+    cmt_destroy(cmt);
+
+    /* --- underflow guard: INT_MAX seconds in ns > current Unix time → nothing dropped --- */
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    g = cmt_gauge_create(cmt, "test", "otel", "cutoff2", "cutoff boundary", 1,
+                         (char *[]) {"host"});
+    TEST_CHECK(g != NULL);
+
+    now = cfl_time_now();
+    cmt_gauge_set(g, now - 1000000000ULL, 1.0, 1, (char *[]) {"a"});
+
+    /* plugin function clamps expiration to 0 → cmt_expire never called */
+    otel_metrics_apply_cutoff(cmt, INT_MAX);
+
+    TEST_CHECK(cfl_list_size(&g->map->metrics) == 1);
+    cmt_destroy(cmt);
+}
+
 /* Test list */
 TEST_LIST = {
     { "hex_to_id", test_hex_to_id },
@@ -3447,5 +3505,7 @@ TEST_LIST = {
       test_opentelemetry_metrics_otlp_proto_batches_all_metric_types },
     { "opentelemetry_metrics_otlp_proto_batches_empty_context",
       test_opentelemetry_metrics_otlp_proto_batches_empty_context },
+    { "opentelemetry_metrics_cutoff",
+      test_opentelemetry_metrics_cutoff },
     { 0 }
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable expiration for metric samples, excluding data older than the selected cutoff before export.
  * Cutoff handling safely supports thresholds beyond the available current time without invalid expiration values.

* **Bug Fixes**
  * Improved error messaging when metric encoding fails, making export issues clearer to diagnose.
  * Added coverage for filtering stale samples while retaining recent data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->